### PR TITLE
Parallel table proxy

### DIFF
--- a/daskms/parallel_table.py
+++ b/daskms/parallel_table.py
@@ -1,0 +1,119 @@
+from pyrap.tables import table as Table
+import logging
+import threading
+from pathlib import Path
+
+
+log = logging.getLogger(__name__)
+
+
+# List of CASA Table methods to proxy and the appropriate locking mode
+_parallel_methods = [
+    ("getcol",),
+    ("getcolslice",),
+    ("getcolnp",),
+    ("getvarcol",),
+    ("getcell",),
+    ("getcellslice",),
+    ("getkeywords",),
+    ("getcolkeywords",),
+]
+
+
+def parallel_method_factory(method):
+    """
+    Proxy pyrap.tables.table.method calls.
+
+    Creates a private implementation function which performs
+    the call locked according to to ``locktype``.
+
+    The private implementation is accessed by a public ``method``
+    which submits a call to the implementation
+    on a concurrent.futures.ThreadPoolExecutor.
+    """
+
+    def _impl(table, args, kwargs):
+        try:
+            return getattr(table, method)(*args, **kwargs)
+        except Exception:
+            if logging.DEBUG >= log.getEffectiveLevel():
+                log.exception("Exception in %s", method)
+            raise
+
+    _impl.__name__ = method + "_impl"
+    _impl.__doc__ = ("Calls table.%s." %
+                     (method))
+
+    def public_method(self, *args, **kwargs):
+        """
+        Submits _impl(args, kwargs) to the executor
+        and returns a Future
+        """
+        return _impl(self._tables[threading.get_ident()], args, kwargs)
+
+    public_method.__name__ = method
+    # public_method.__doc__ = _PROXY_DOCSTRING % method
+
+    return public_method
+
+
+class ParallelTableMetaClass(type):
+
+    def __new__(cls, name, bases, dct):
+        for (method,) in _parallel_methods:
+            parallel_method = parallel_method_factory(method)
+            dct[method] = parallel_method
+
+        return type.__new__(cls, name, bases, dct)
+
+    # def __call__(cls, *args, **kwargs):
+    #     key = arg_hasher((cls,) + args + (kwargs,))
+
+    #     with _table_lock:
+    #         try:
+    #             return _table_cache[key]
+    #         except KeyError:
+    #             instance = type.__call__(cls, *args, **kwargs)
+    #             _table_cache[key] = instance
+    #             return instance
+
+
+class ParallelTable(Table):
+
+    def __init__(self, *args, **kwargs):
+
+        self._args = args
+        self._kwargs = kwargs
+
+        self._linked_tables = {}
+        self._table_path = args[0]  # TODO: This should be checked.
+
+        super().__init__(*args, **kwargs)
+
+    def getcolnp(self, *args, **kwargs):
+
+        thread_id = threading.get_ident()
+
+        return self.get_table(thread_id).getcolnp(*args, **kwargs)
+
+    def get_table(self, thread_id):
+
+        try:
+            table = self._linked_tables[thread_id]
+        except KeyError:
+            table_path = Path(self._table_path)
+            table_name = table_path.name
+            link_path = Path(f"/tmp/{thread_id}-{table_name}")
+
+            try:
+                link_path.symlink_to(table_path)
+            except FileExistsError:  # This should raise a warning.
+                link_path.unlink()
+                link_path.symlink_to(table_path)
+
+            self._linked_tables[thread_id] = table = Table(
+                str(link_path),
+                **self._kwargs
+            )
+
+        return table

--- a/daskms/parallel_table.py
+++ b/daskms/parallel_table.py
@@ -1,82 +1,11 @@
-from pyrap.tables import table as Table
 import logging
 import threading
+from pyrap.tables import table as Table
 from pathlib import Path
 from weakref import finalize
 
 
 log = logging.getLogger(__name__)
-
-
-# List of CASA Table methods to proxy and the appropriate locking mode
-_parallel_methods = [
-    ("getcol",),
-    ("getcolslice",),
-    ("getcolnp",),
-    ("getvarcol",),
-    ("getcell",),
-    ("getcellslice",),
-    ("getkeywords",),
-    ("getcolkeywords",),
-]
-
-
-def parallel_method_factory(method):
-    """
-    Proxy pyrap.tables.table.method calls.
-
-    Creates a private implementation function which performs
-    the call locked according to to ``locktype``.
-
-    The private implementation is accessed by a public ``method``
-    which submits a call to the implementation
-    on a concurrent.futures.ThreadPoolExecutor.
-    """
-
-    def _impl(table, args, kwargs):
-        try:
-            return getattr(table, method)(*args, **kwargs)
-        except Exception:
-            if logging.DEBUG >= log.getEffectiveLevel():
-                log.exception("Exception in %s", method)
-            raise
-
-    _impl.__name__ = method + "_impl"
-    _impl.__doc__ = ("Calls table.%s." %
-                     (method))
-
-    def public_method(self, *args, **kwargs):
-        """
-        Submits _impl(args, kwargs) to the executor
-        and returns a Future
-        """
-        return _impl(self._tables[threading.get_ident()], args, kwargs)
-
-    public_method.__name__ = method
-    # public_method.__doc__ = _PROXY_DOCSTRING % method
-
-    return public_method
-
-
-class ParallelTableMetaClass(type):
-
-    def __new__(cls, name, bases, dct):
-        for (method,) in _parallel_methods:
-            parallel_method = parallel_method_factory(method)
-            dct[method] = parallel_method
-
-        return type.__new__(cls, name, bases, dct)
-
-    # def __call__(cls, *args, **kwargs):
-    #     key = arg_hasher((cls,) + args + (kwargs,))
-
-    #     with _table_lock:
-    #         try:
-    #             return _table_cache[key]
-    #         except KeyError:
-    #             instance = type.__call__(cls, *args, **kwargs)
-    #             _table_cache[key] = instance
-    #             return instance
 
 
 def _parallel_table_finalizer(_linked_tables):
@@ -102,13 +31,39 @@ class ParallelTable(Table):
 
         finalize(self, _parallel_table_finalizer, self._linked_tables)
 
+    def getcol(self, *args, **kwargs):
+        table = self._get_table(threading.get_ident())
+        return table.getcol(*args, **kwargs)
+
+    def getcolslice(self, *args, **kwargs):
+        table = self._get_table(threading.get_ident())
+        return table.getcolslice(*args, **kwargs)
+
     def getcolnp(self, *args, **kwargs):
+        table = self._get_table(threading.get_ident())
+        return table.getcolnp(*args, **kwargs)
 
-        thread_id = threading.get_ident()
+    def getvarcol(self, *args, **kwargs):
+        table = self._get_table(threading.get_ident())
+        return table.getvarcol(*args, **kwargs)
 
-        return self.get_table(thread_id).getcolnp(*args, **kwargs)
+    def getcell(self, *args, **kwargs):
+        table = self._get_table(threading.get_ident())
+        return table.getcell(*args, **kwargs)
 
-    def get_table(self, thread_id):
+    def getcellslice(self, *args, **kwargs):
+        table = self._get_table(threading.get_ident())
+        return table.getcellslice(*args, **kwargs)
+
+    def getkeywords(self, *args, **kwargs):
+        table = self._get_table(threading.get_ident())
+        return table.getkeywords(*args, **kwargs)
+
+    def getcolkeywords(self, *args, **kwargs):
+        table = self._get_table(threading.get_ident())
+        return table.getcolkeywords(*args, **kwargs)
+
+    def _get_table(self, thread_id):
 
         try:
             table = self._linked_tables[thread_id]
@@ -117,11 +72,7 @@ class ParallelTable(Table):
             table_name = table_path.name
             link_path = Path(f"/tmp/{thread_id}-{table_name}")
 
-            try:
-                link_path.symlink_to(table_path)
-            except FileExistsError:  # This should raise a warning.
-                link_path.unlink()
-                link_path.symlink_to(table_path)
+            link_path.symlink_to(table_path)
 
             self._linked_tables[thread_id] = table = Table(
                 str(link_path),

--- a/daskms/parallel_table.py
+++ b/daskms/parallel_table.py
@@ -80,6 +80,8 @@ class ParallelTable(Table):
         try:
             table = self._cached_tables[thread_id]
         except KeyError:
+            print(f"opening for {thread_id}")
+
             self._cached_tables[thread_id] = table = Table(
                 *self._args,
                 **self._kwargs

--- a/daskms/parallel_table.py
+++ b/daskms/parallel_table.py
@@ -1,16 +1,10 @@
 import logging
 import threading
 from pyrap.tables import table as Table
-from pathlib import Path
 from weakref import finalize
 
 
 log = logging.getLogger(__name__)
-
-
-def _map_create_parallel_table(cls, args, kwargs):
-    """ Support pickling of kwargs in ParallelTable.__reduce__ """
-    return cls(*args, **kwargs)
 
 
 def _parallel_table_finalizer(_cached_tables):
@@ -20,6 +14,11 @@ def _parallel_table_finalizer(_cached_tables):
 
 
 class ParallelTable(Table):
+
+    @classmethod
+    def _map_create_parallel_table(cls, args, kwargs):
+        """ Support pickling of kwargs in ParallelTable.__reduce__ """
+        return cls(*args, **kwargs)
 
     def __init__(self, *args, **kwargs):
 
@@ -36,7 +35,7 @@ class ParallelTable(Table):
     def __reduce__(self):
         """ Defer to _map_create_parallel_table to support kwarg pickling """
         return (
-            _map_create_parallel_table,
+            ParallelTable._map_create_parallel_table,
             (ParallelTable, self._args, self._kwargs)
         )
 

--- a/daskms/parallel_table.py
+++ b/daskms/parallel_table.py
@@ -16,10 +16,7 @@ def _map_create_parallel_table(cls, args, kwargs):
 def _parallel_table_finalizer(_cached_tables):
 
     for table in _cached_tables.values():
-
-        link_path = Path(table.name())
         table.close()
-        # link_path.unlink()
 
 
 class ParallelTable(Table):

--- a/daskms/table_executor.py
+++ b/daskms/table_executor.py
@@ -38,7 +38,7 @@ class ExecutorMetaClass(type):
 class Executor(object, metaclass=ExecutorMetaClass):
     def __init__(self, key=STANDARD_EXECUTOR):
         # Initialise a single thread
-        self.impl = impl = cf.ThreadPoolExecutor(1)
+        self.impl = impl = cf.ThreadPoolExecutor(4)
         self.key = key
 
         # Register a finaliser shutting down the

--- a/daskms/table_executor.py
+++ b/daskms/table_executor.py
@@ -38,7 +38,7 @@ class ExecutorMetaClass(type):
 class Executor(object, metaclass=ExecutorMetaClass):
     def __init__(self, key=STANDARD_EXECUTOR):
         # Initialise a single thread
-        self.impl = impl = cf.ThreadPoolExecutor(4)
+        self.impl = impl = cf.ThreadPoolExecutor(1)
         self.key = key
 
         # Register a finaliser shutting down the

--- a/daskms/table_executor.py
+++ b/daskms/table_executor.py
@@ -77,6 +77,7 @@ class DummyFuture(object):
 
         return self.value
 
+
 def executor_key(table_name):
     """
     Product an executor key from table_name

--- a/daskms/table_executor.py
+++ b/daskms/table_executor.py
@@ -38,7 +38,7 @@ class ExecutorMetaClass(type):
 class Executor(object, metaclass=ExecutorMetaClass):
     def __init__(self, key=STANDARD_EXECUTOR):
         # Initialise a single thread
-        self.impl = impl = cf.ThreadPoolExecutor(4)
+        self.impl = impl = DummyThreadPoolExecutor(1)
         self.key = key
 
         # Register a finaliser shutting down the
@@ -53,6 +53,29 @@ class Executor(object, metaclass=ExecutorMetaClass):
 
     __str__ = __repr__
 
+
+class DummyThreadPoolExecutor(object):
+
+    def __init__(self, nthread):
+        pass
+
+    def submit(self, fn, *args, **kwargs):
+
+        return DummyFuture(fn(*args, **kwargs))
+
+    def shutdown(self, wait=True):
+        pass
+
+
+class DummyFuture(object):
+
+    def __init__(self, value):
+
+        self.value = value
+
+    def result(self):
+
+        return self.value
 
 def executor_key(table_name):
     """

--- a/daskms/tests/test_table_proxy.py
+++ b/daskms/tests/test_table_proxy.py
@@ -239,8 +239,8 @@ def test_softlinks(ms, scheduler):
 
         cluster = LocalCluster(
             processes=True,
-            n_workers=1,
-            threads_per_worker=1,
+            n_workers=2,
+            threads_per_worker=2,
             memory_limit=0
         )
 

--- a/daskms/tests/test_table_proxy.py
+++ b/daskms/tests/test_table_proxy.py
@@ -228,14 +228,11 @@ def test_proxy_finalization(tmpdir_factory, epochs, iterations):
                          ["sync", "threads", "processes", "distributed"])
 def test_softlinks(ms, scheduler):
 
-    import dask
     import dask.array as da
     from dask.distributed import Client, LocalCluster
     from daskms import xds_from_ms
 
     if scheduler == "distributed":
-
-        # dask.config.set({"distributed.worker.daemon": False})
 
         cluster = LocalCluster(
             processes=True,

--- a/daskms/tests/test_table_proxy.py
+++ b/daskms/tests/test_table_proxy.py
@@ -235,7 +235,7 @@ def test_softlinks(ms, scheduler):
 
     if scheduler == "distributed":
 
-        dask.config.set({"distributed.worker.daemon": False})
+        # dask.config.set({"distributed.worker.daemon": False})
 
         cluster = LocalCluster(
             processes=True,
@@ -246,12 +246,16 @@ def test_softlinks(ms, scheduler):
 
         client = Client(cluster)  # noqa
 
-    ms = "/home/jonathan/reductions/3C147/msdir/C147_unflagged.MS"
+    # ms = "/home/jonathan/reductions/3C147/msdir/C147_unflagged.MS"
+    ms = "/home/jonathan/recipes/proxy_experiments/vla_empty.ms"
 
     xdsl = xds_from_ms(
         ms,
         group_cols=["DATA_DESC_ID", "SCAN_NUMBER", "FIELD_ID"],
-        chunks={"row": -1, "chan": -1, "corr": -1}
+        chunks={"row": 30000, "chan": -1, "corr": -1}
     )
 
-    da.compute(xdsl[:10], scheduler=scheduler, num_workers=4)
+    result = [xds.DATA.sum() for xds in xdsl]
+
+    with dask.config.set({"multiprocessing.context": "spawn"}):
+        da.compute(result, scheduler=scheduler, num_workers=4)

--- a/daskms/tests/test_table_proxy.py
+++ b/daskms/tests/test_table_proxy.py
@@ -240,7 +240,7 @@ def test_softlinks(ms, scheduler):
         cluster = LocalCluster(
             processes=True,
             n_workers=1,
-            threads_per_worker=2,
+            threads_per_worker=1,
             memory_limit=0
         )
 
@@ -250,9 +250,8 @@ def test_softlinks(ms, scheduler):
 
     xdsl = xds_from_ms(
         ms,
-        group_cols=["DATA_DESC_ID", "SCAN_NUMBER", "FIELD_ID"]
+        group_cols=["DATA_DESC_ID", "SCAN_NUMBER", "FIELD_ID"],
+        chunks={"row": -1, "chan": -1, "corr": -1}
     )
 
-    xdsl = xdsl[:8]
-
-    da.compute(xdsl, scheduler=scheduler, num_workers=4)
+    da.compute(xdsl[:10], scheduler=scheduler, num_workers=4)

--- a/daskms/tests/test_table_proxy.py
+++ b/daskms/tests/test_table_proxy.py
@@ -255,7 +255,6 @@ def test_softlinks(ms, scheduler):
         chunks={"row": 30000, "chan": -1, "corr": -1}
     )
 
-    result = [xds.DATA.sum() for xds in xdsl]
+    result = [xds.DATA.data.map_blocks(lambda x: x[:1, :1, :1]) for xds in xdsl]
 
-    with dask.config.set({"multiprocessing.context": "spawn"}):
-        da.compute(result, scheduler=scheduler, num_workers=4)
+    da.compute(result, scheduler=scheduler, num_workers=4)


### PR DESCRIPTION
- [ ] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [ ] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```

This is al alternative approach to #185. I decided to make it a separate PR as they are vastly different. Apologies for repo clutter.
I am not sure if what I have done here is what you were expecting @sjperkins. I really am just feeling my way at this point. This doesn't subclass `pyrap.tables.table` but will create more churn. As I mentioned in the other PR, care has to be taken as some functions access tables via `_table_future` and some access functions via the `TableProxy`.