### PR TITLE
Ensure that xds_from_zarr sorts groups as integers and not strings.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Ensure that `xds_from_zarr` sorts groups as integers and not strings (:pr:`188`)
 * Ensure Natural Ordering for parquet files (:pr:`183)
 * Fix xds_from_zarr and xds_from_parquet chunking behaviour (:pr:`182`)
 * Add LazyProxy and LazyProxyMultiton patterns to dask-ms (:pr:`177`)

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -256,6 +256,10 @@ def zarr_getter(zarray, *extents):
     return zarray[tuple(slice(start, end) for start, end in extents)]
 
 
+def group_sortkey(element):
+    return int(element[0].split('_')[-1])
+
+
 @requires("pip install dask-ms[zarr] for zarr support",
           zarr_import_error)
 def xds_from_zarr(store, columns=None, chunks=None):
@@ -305,7 +309,8 @@ def xds_from_zarr(store, columns=None, chunks=None):
 
     table_group = zarr.open(store.map)[store.table]
 
-    for g, (group_name, group) in enumerate(sorted(table_group.groups())):
+    for g, (group_name, group) in enumerate(sorted(table_group.groups(),
+                                                   key=group_sortkey)):
         group_attrs = decode_attr(dict(group.attrs))
         dask_ms_attrs = group_attrs.pop(DASKMS_ATTR_KEY)
         natural_chunks = dask_ms_attrs["chunks"]

--- a/daskms/experimental/zarr/tests/test_zarr.py
+++ b/daskms/experimental/zarr/tests/test_zarr.py
@@ -238,3 +238,14 @@ def test_fasteners(ms, tmp_path_factory):
         results = [pool.apply_async(_fasteners_runner, (lockfile,))
                    for _ in range(4)]
         pprint([r.get() for r in results])
+
+
+def test_basic_roundtrip(tmp_path):
+
+    path = tmp_path / "test.zarr"
+
+    xdsl = [xarray.Dataset({'x': (('y',), da.ones(i))}) for i in range(1, 12)]
+    dask.compute(xds_to_zarr(xdsl, path))
+
+    xdsl = xds_from_zarr('test.zarr')
+    dask.compute(xds_to_zarr(xdsl, path))

--- a/daskms/experimental/zarr/tests/test_zarr.py
+++ b/daskms/experimental/zarr/tests/test_zarr.py
@@ -247,5 +247,5 @@ def test_basic_roundtrip(tmp_path):
     xdsl = [xarray.Dataset({'x': (('y',), da.ones(i))}) for i in range(1, 12)]
     dask.compute(xds_to_zarr(xdsl, path))
 
-    xdsl = xds_from_zarr('test.zarr')
+    xdsl = xds_from_zarr(path)
     dask.compute(xds_to_zarr(xdsl, path))

--- a/daskms/experimental/zarr/tests/test_zarr.py
+++ b/daskms/experimental/zarr/tests/test_zarr.py
@@ -245,7 +245,7 @@ def test_basic_roundtrip(tmp_path):
     path = tmp_path / "test.zarr"
 
     # We need >10 datasets to be sure roundtripping is consistent.
-    xdsl = [xarray.Dataset({'x': (('y',), da.ones(i))}) for i in range(1, 12)]
+    xdsl = [Dataset({'x': (('y',), da.ones(i))}) for i in range(1, 12)]
     dask.compute(xds_to_zarr(xdsl, path))
 
     xdsl = xds_from_zarr(path)

--- a/daskms/experimental/zarr/tests/test_zarr.py
+++ b/daskms/experimental/zarr/tests/test_zarr.py
@@ -244,6 +244,7 @@ def test_basic_roundtrip(tmp_path):
 
     path = tmp_path / "test.zarr"
 
+    # We need >10 datasets to be sure roundtripping is consistent.
     xdsl = [xarray.Dataset({'x': (('y',), da.ones(i))}) for i in range(1, 12)]
     dask.compute(xds_to_zarr(xdsl, path))
 


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```

Currently `xds_from_zarr` will sort zarr groups as strings rather than by the integer value in those strings. This causes problems as `xds_to_zarr` does not do an equivalent sort and simply writes the groups in order. This change will make the `xds_from_zarr` behaviour the same as the `xds_to_zarr` behvaiour. This behaviour can probably be improved and refined in the future as we do not currently support partial writes i.e. you will end up writing to the wrong place if you were to omit some datasets.

@landmanbester, please give it a spin and let me know if it fixes or further breaks your code.