### PR TITLE
Differentiate between uniform and non uniform subtables.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Improve handling of subtables with variably sized rows in daskms-convert.
 * Ensure that `xds_from_zarr` sorts groups as integers and not strings (:pr:`188`)
 * Ensure Natural Ordering for parquet files (:pr:`183)
 * Fix xds_from_zarr and xds_from_parquet chunking behaviour (:pr:`182`)

--- a/daskms/apps/convert.py
+++ b/daskms/apps/convert.py
@@ -252,6 +252,9 @@ class ParquetFormat(BaseTableFormat):
         return "parquet"
 
 
+NONUNIFORM_SUBTABLES = ["SPECTRAL_WINDOW", "POLARIZATION", "FEED", "SOURCE"]
+
+
 def convert_table(args):
     in_fmt = TableFormat.from_path(args.input)
     out_fmt = TableFormat.from_type(args.format)
@@ -285,7 +288,7 @@ def convert_table(args):
         reader = in_fmt.reader()
         writer = out_fmt.writer()
 
-        if isinstance(in_fmt, CasaFormat):
+        if isinstance(in_fmt, CasaFormat) and table in NONUNIFORM_SUBTABLES:
             # Drop any ROWID columns
             datasets = [ds.drop_vars("ROWID", errors="ignore")
                         for ds in reader(in_path, group_cols="__row__")]


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
