### PR TITLE
Fix #175 for xds_from_storage_* functions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,8 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
-* Improve handling of subtables with variably sized rows in daskms-convert.
+* Fix #175 for xds_from_storage_* functions. (:pr:`192`)
+* Improve handling of subtables with variably sized rows in daskms-convert. (:pr:`191`)
 * Ensure that `xds_from_zarr` sorts groups as integers and not strings (:pr:`188`)
 * Ensure Natural Ordering for parquet files (:pr:`183)
 * Fix xds_from_zarr and xds_from_parquet chunking behaviour (:pr:`182`)

--- a/daskms/apps/convert.py
+++ b/daskms/apps/convert.py
@@ -252,6 +252,9 @@ class ParquetFormat(BaseTableFormat):
         return "parquet"
 
 
+NONUNIFORM_SUBTABLES = ["SPECTRAL_WINDOW", "POLARIZATION", "FEED", "SOURCE"]
+
+
 def convert_table(args):
     in_fmt = TableFormat.from_path(args.input)
     out_fmt = TableFormat.from_type(args.format)
@@ -285,7 +288,7 @@ def convert_table(args):
         reader = in_fmt.reader()
         writer = out_fmt.writer()
 
-        if isinstance(in_fmt, CasaFormat):
+        if isinstance(in_fmt, CasaFormat) and table in NONUNIFORM_SUBTABLES:
             # Drop any ROWID columns
             datasets = [ds.drop_vars("ROWID", errors="ignore")
                         for ds in reader(in_path, group_cols="__row__")]

--- a/daskms/experimental/arrow/reads.py
+++ b/daskms/experimental/arrow/reads.py
@@ -179,7 +179,16 @@ def partition_chunking(partition, fragment_rows, chunks):
 
 
 @requires_arrow(pyarrow_import_error)
-def xds_from_parquet(store, columns=None, chunks=None):
+def xds_from_parquet(store, columns=None, chunks=None, **kwargs):
+
+    # If any kwargs are added, they should be popped prior to this check.
+    if len(kwargs) > 0:
+        warnings.warn(
+            f"The following unsupported kwargs were ignored in "
+            f"xds_from_parquet: {kwargs}",
+            UserWarning,
+        )
+
     if isinstance(store, DaskMSStore):
         pass
     elif isinstance(store, Path):

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -6,6 +6,7 @@ from dask.array.core import normalize_chunks
 from dask.base import tokenize
 import numcodecs
 import numpy as np
+import warnings
 
 from daskms.constants import DASKMS_PARTITION_KEY
 from daskms.dataset import Dataset, Variable
@@ -262,7 +263,7 @@ def group_sortkey(element):
 
 @requires("pip install dask-ms[zarr] for zarr support",
           zarr_import_error)
-def xds_from_zarr(store, columns=None, chunks=None):
+def xds_from_zarr(store, columns=None, chunks=None, **kwargs):
     """
     Reads the zarr data store in `store` and returns list of
     Dataset's containing the data.
@@ -276,12 +277,22 @@ def xds_from_zarr(store, columns=None, chunks=None):
         Otherwise, a list of columns should be supplied.
     chunks: dict or list of dicts
         chunking schema for each dataset
+    **kwargs: optional
 
     Returns
     -------
     writes : Dataset or list of Datasets
         Dataset(s) representing write operations
     """
+
+    # If any kwargs are added, they should be popped prior to this check.
+    if len(kwargs) > 0:
+        warnings.warn(
+            f"The following unsupported kwargs were ignored in "
+            f"xds_from_zarr: {kwargs}",
+            UserWarning,
+        )
+
     if isinstance(store, DaskMSStore):
         pass
     elif isinstance(store, Path):

--- a/daskms/fsspec_store.py
+++ b/daskms/fsspec_store.py
@@ -97,7 +97,9 @@ class DaskMSStore(metaclass=Multiton):
 
     def rglob(self, pattern, **kwargs):
         sep = self.fs.sep
-        fullpath = "".join((self.path, sep, self.table, sep, "**", sep, pattern))
+        fullpath = "".join(
+            (self.path, sep, self.table, sep, "**", sep, pattern)
+        )
         paths = self.fs.glob(fullpath, **kwargs)
         prefix = "".join((self.path, sep))
         return (self._remove_prefix(p, prefix) for p in paths)

--- a/daskms/fsspec_store.py
+++ b/daskms/fsspec_store.py
@@ -97,7 +97,7 @@ class DaskMSStore(metaclass=Multiton):
 
     def rglob(self, pattern, **kwargs):
         sep = self.fs.sep
-        fullpath = "".join((self.path, sep, "**", sep, pattern))
+        fullpath = "".join((self.path, sep, self.table, sep, "**", sep, pattern))
         paths = self.fs.glob(fullpath, **kwargs)
         prefix = "".join((self.path, sep))
         return (self._remove_prefix(p, prefix) for p in paths)


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
