### PR TITLE
Fix #172.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Fix #172 - error out when missing datavars should be written. (:pr:`197`)
 * Fix #195 - allow non-standard columns to be tiled. (:pr:`196`)
 
 0.2.8 (2022-04-06)

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -231,9 +231,16 @@ def xds_to_zarr(xds, store, columns=None):
     write_datasets = []
 
     for di, ds in enumerate(xds):
-        group = prepare_zarr_group(di, ds, store)
 
         data_vars, coords = select_vars_and_coords(ds, columns)
+
+        if not data_vars:
+            raise ValueError(f"User requested writes on the following "
+                             f"columns: {columns}. Some or all of these "
+                             f"are not present on the datasets. Aborting.")
+
+        group = prepare_zarr_group(di, ds, store)
+
         data_vars = dict(_gen_writes(data_vars, ds.chunks, group))
         # Include coords in the write dataset so they're reified
         data_vars.update(dict(_gen_writes(coords, ds.chunks, group,


### PR DESCRIPTION
 Raise an error when user requests writes on missing data vars (or using incorrect special args).

- [X] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
