### PR TITLE
Better fix for #172.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Improve fix for #172 - error out more reliably. (:pr:`198`)
 * Fix #172 - error out when missing datavars should be written. (:pr:`197`)
 * Fix #195 - allow non-standard columns to be tiled. (:pr:`196`)
 

--- a/daskms/experimental/utils.py
+++ b/daskms/experimental/utils.py
@@ -75,8 +75,16 @@ def select_vars_and_coords(dataset, columns):
         column_set = set(columns)
         data_vars = dataset.data_vars
         coords = dataset.coords
-        data_cols = column_set & set(data_vars.keys())
-        coord_cols = column_set & set(coords.keys())
+        data_var_names = set(data_vars.keys())
+        coord_names = set(coords.keys())
+
+        if not column_set.issubset((data_var_names | coord_names)):
+            raise ValueError(f"User requested writes on the following "
+                             f"columns: {column_set}. Some or all of these "
+                             f"are not present on the datasets. Aborting.")
+
+        data_cols = column_set & data_var_names
+        coord_cols = column_set & coord_names
 
         for c in coord_cols:
             coord_cols.union(*(d for d in coords[c].dims))

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -234,11 +234,6 @@ def xds_to_zarr(xds, store, columns=None):
 
         data_vars, coords = select_vars_and_coords(ds, columns)
 
-        if not data_vars:
-            raise ValueError(f"User requested writes on the following "
-                             f"columns: {columns}. Some or all of these "
-                             f"are not present on the datasets. Aborting.")
-
         group = prepare_zarr_group(di, ds, store)
 
         data_vars = dict(_gen_writes(data_vars, ds.chunks, group))


### PR DESCRIPTION
- [X] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.
  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```

Previous fix was flawed when specifying multiple columns. New solution should handle all cases correctly. Note that working on this PR has exposed odd behaviour in `xds_to_zarr`. I will open an issue shortly.
