### PR TITLE
Fix #199.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Fix #199 - do not create spurious fields in zarr writes. (:pr:`200`)
 * Improve fix for #172 - error out more reliably. (:pr:`198`)
 * Fix #172 - error out when missing datavars should be written. (:pr:`197`)
 * Fix #195 - allow non-standard columns to be tiled. (:pr:`196`)

--- a/daskms/experimental/utils.py
+++ b/daskms/experimental/utils.py
@@ -86,8 +86,8 @@ def select_vars_and_coords(dataset, columns):
         data_sel = column_set & data_var_names
         coord_sel = column_set & coord_names
 
-        for v in data_vars.values():
-            coord_sel = coord_sel.union(*v.coords.keys())
+        for dv in data_sel:
+            coord_sel = coord_sel.union(*data_vars[dv].coords.keys())
 
         ret_data_vars = {col: data_vars[col] for col in data_sel}
         ret_coords = {c: coords[c] for c in coord_sel}

--- a/daskms/experimental/utils.py
+++ b/daskms/experimental/utils.py
@@ -83,27 +83,14 @@ def select_vars_and_coords(dataset, columns):
                              f"columns: {column_set}. Some or all of these "
                              f"are not present on the datasets. Aborting.")
 
-        data_cols = column_set & data_var_names
-        coord_cols = column_set & coord_names
+        data_sel = column_set & data_var_names
+        coord_sel = column_set & coord_names
 
-        for c in coord_cols:
-            coord_cols.union(*(d for d in coords[c].dims))
+        for v in data_vars.values():
+            coord_sel = coord_sel.union(*v.coords.keys())
 
-        ret_data_vars = {}
-
-        for c in data_cols:
-            ret_data_vars[c] = v = data_vars[c]
-            coord_cols.union(*(d for d in v.dims))
-
-        ret_coords = {}
-
-        for c in coord_cols:
-            try:
-                v = coords[c]
-            except KeyError:
-                continue
-            else:
-                ret_coords[c] = v
+        ret_data_vars = {col: data_vars[col] for col in data_sel}
+        ret_coords = {c: coords[c] for c in coord_sel}
 
     return ret_data_vars, ret_coords
 

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -201,7 +201,8 @@ def xds_to_zarr(xds, store, columns=None):
         Path to store the data
     columns : list of str or str or None
         Columns to store. `None` or `"ALL"` stores all columns on each dataset.
-        Otherwise, a list of columns should be supplied.
+        Otherwise, a list of columns should be supplied. All coordinates
+        associated with a specified column will be written automatically.
 
     Returns
     -------
@@ -233,6 +234,9 @@ def xds_to_zarr(xds, store, columns=None):
     for di, ds in enumerate(xds):
 
         data_vars, coords = select_vars_and_coords(ds, columns)
+
+        # Create a new ds which is consistent with what we want to write.
+        ds = Dataset(data_vars, coords=coords, attrs=ds.attrs)
 
         group = prepare_zarr_group(di, ds, store)
 


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```

This changes the behaviour of `xds_to_zarr`. A new dataset will be constructed after selection of `data_vars` and `coords` but before construction of the schemas. This means that selecting columns (data_vars) will no longer produce partially initialised values for unselected data_vars/coords. This also begins addressing #171 and #118 (for zarr) - more work will still be needed to reconcile chunking and propagate the changes to the casa/parquet interfaces.