### PR TITLE
Fix #205 - Add `xds_to_storage_table`.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Fix #205 - Add xds_to_storage_table. (:pr:`207`)
 * Fix #187 - add option to rechunk automatically on writes. (:pr:`204`)
 * Fix #118 - raise more informative error. (:pr:`203`)
 * Fix #201 - improve tiling. (:pr:`202`)

--- a/daskms/__init__.py
+++ b/daskms/__init__.py
@@ -8,11 +8,12 @@ __version__ = "0.2.8"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-from daskms.dask_ms import (xds_from_storage_ms, xds_from_table,      # noqa
-                                xds_to_table,    # noqa
-                                xds_from_ms,     # noqa
-                                xds_from_storage_ms,     # noqa
-                                xds_from_storage_table)  # noqa
+from daskms.dask_ms import (xds_from_table,  # noqa
+                            xds_from_ms,  # noqa
+                            xds_from_storage_ms,  # noqa
+                            xds_from_storage_table,  # noqa
+                            xds_to_table,  # noqa
+                            xds_to_storage_table)  # noqa
 
 from daskms.dataset import Dataset, Variable     # noqa
 from daskms.table_proxy import TableProxy        # noqa

--- a/daskms/dask_ms.py
+++ b/daskms/dask_ms.py
@@ -72,13 +72,21 @@ def xds_to_table(xds, table_name, columns="ALL", descriptor=None,
         The Table Proxy associated with the datasets
     """
     if isinstance(table_name, DaskMSStore):
-        table_name = table_name.casa_path()
+        store = table_name
     else:
-        table_name = DaskMSStore(table_name).casa_path()
+        store = DaskMSStore(table_name)
+
+    table_name = store.casa_path()
 
     # Promote dataset to a list
     if not isinstance(xds, (tuple, list)):
         xds = [xds]
+
+    # Not writing to an existing dataset so we drop ROWID to ensure that rows
+    # get added correctly. TODO: This may be a little brittle - we could
+    # consider altering the functionality in writes.py.
+    if not store.exists():
+        xds = [ds.drop_vars("ROWID", errors="ignore") for ds in xds]
 
     if not isinstance(columns, (tuple, list)):
         if columns != "ALL":
@@ -346,6 +354,24 @@ def xds_from_storage_ms(store, **kwargs):
     elif typ == "parquet":
         from daskms.experimental.arrow import xds_from_parquet
         return xds_from_parquet(store, **kwargs)
+    else:
+        raise TypeError(f"Unknown dataset {typ}")
+
+
+def xds_to_storage_table(xds, store, **kwargs):
+    if not isinstance(store, DaskMSStore):
+        store = DaskMSStore(store)
+
+    typ = store.type()
+
+    if typ == "casa":
+        return xds_to_table(xds, store,  **kwargs)
+    elif typ == "zarr":
+        from daskms.experimental.zarr import xds_to_zarr
+        return xds_to_zarr(xds, store, **kwargs)
+    elif typ == "parquet":
+        from daskms.experimental.arrow import xds_to_parquet
+        return xds_to_parquet(xds, store, **kwargs)
     else:
         raise TypeError(f"Unknown dataset {typ}")
 

--- a/daskms/dask_ms.py
+++ b/daskms/dask_ms.py
@@ -6,7 +6,7 @@ from daskms.fsspec_store import DaskMSStore
 from daskms.table_proxy import TableProxy
 from daskms.reads import DatasetFactory
 from daskms.writes import write_datasets
-from daskms.utils import promote_columns
+from daskms.utils import promote_columns, filter_kwargs
 
 _DEFAULT_INDEX_COLUMNS = []
 _DEFAULT_GROUP_COLUMNS = ["FIELD_ID", "DATA_DESC_ID"]
@@ -365,12 +365,15 @@ def xds_to_storage_table(xds, store, **kwargs):
     typ = store.type()
 
     if typ == "casa":
+        filter_kwargs(xds_to_table, kwargs)
         return xds_to_table(xds, store,  **kwargs)
     elif typ == "zarr":
         from daskms.experimental.zarr import xds_to_zarr
+        filter_kwargs(xds_to_zarr, kwargs)
         return xds_to_zarr(xds, store, **kwargs)
     elif typ == "parquet":
         from daskms.experimental.arrow import xds_to_parquet
+        filter_kwargs(xds_to_parquet, kwargs)
         return xds_to_parquet(xds, store, **kwargs)
     else:
         raise TypeError(f"Unknown dataset {typ}")

--- a/daskms/dataset.py
+++ b/daskms/dataset.py
@@ -425,7 +425,7 @@ else:
             try:
                 return self._attrs[name]
             except KeyError:
-                raise AttributeError(f"Invalid Attribute {name}")
+                raise AttributeError(f"Invalid item {name}")
 
         def __getattr__(self, name):
             try:

--- a/daskms/experimental/arrow/reads.py
+++ b/daskms/experimental/arrow/reads.py
@@ -115,7 +115,7 @@ def _partition_values(partition_strings, partition_meta):
                              f"metadata column name {pf}")
 
         # NOTE(JSKenyon): Use item to get a python type. Coercing to numpy
-        # type is not used for the other formats and cuases serialization
+        # type is not used for the other formats and causes serialization
         # woes.
         partitions.append((field, np.dtype(dt).type(value).item()))
 

--- a/daskms/experimental/arrow/reads.py
+++ b/daskms/experimental/arrow/reads.py
@@ -114,7 +114,10 @@ def _partition_values(partition_strings, partition_meta):
                              f"{partition_strings} does not match "
                              f"metadata column name {pf}")
 
-        partitions.append((field, np.dtype(dt).type(value)))
+        # NOTE(JSKenyon): Use item to get a python type. Coercing to numpy
+        # type is not used for the other formats and cuases serialization
+        # woes.
+        partitions.append((field, np.dtype(dt).type(value).item()))
 
     return tuple(partitions)
 

--- a/daskms/fsspec_store.py
+++ b/daskms/fsspec_store.py
@@ -83,8 +83,11 @@ class DaskMSStore(metaclass=Multiton):
     def __getitem__(self, key):
         return self.map[key]
 
-    def exists(self, path):
-        fullpath = "".join((self.path, self.fs.sep, path))
+    def exists(self, path=None):
+        if path:
+            fullpath = "".join((self.path, self.fs.sep, path))
+        else:
+            fullpath = self.path
         return self.fs.exists(fullpath)
 
     def ls(self, path=None):

--- a/daskms/tests/test_storage.py
+++ b/daskms/tests/test_storage.py
@@ -69,6 +69,6 @@ def test_storage_parquet(ms, tmp_path_factory):
 
     dask.compute(writes)
 
-    xdsl = dask.compute(xds_from_parquet(parquet_store), scheduler='sync')[0]
+    xdsl = dask.compute(xds_from_parquet(parquet_store))[0]
 
     assert all([xds.equals(oxds) for xds, oxds in zip(xdsl, oxdsl)])

--- a/daskms/tests/test_storage.py
+++ b/daskms/tests/test_storage.py
@@ -1,0 +1,67 @@
+import dask
+from daskms import xds_to_storage_table, xds_from_ms
+from daskms.experimental.zarr import xds_from_zarr, xds_to_zarr
+from daskms.experimental.arrow import xds_from_parquet, xds_to_parquet
+
+
+def test_storage_ms(ms):
+
+    oxdsl = xds_from_ms(ms)
+
+    writes = xds_to_storage_table(oxdsl, ms)
+
+    oxdsl = dask.compute(oxdsl)[0]
+
+    dask.compute(writes)
+
+    xdsl = dask.compute(xds_from_ms(ms))[0]
+
+    assert all([xds.equals(oxds) for xds, oxds in zip(xdsl, oxdsl)])
+
+
+def test_storage_zarr(ms, tmp_path_factory):
+
+    zarr_store = tmp_path_factory.mktemp("zarr") / "test.zarr"
+
+    oxdsl = xds_from_ms(ms)
+
+    writes = xds_to_zarr(oxdsl, zarr_store)
+
+    dask.compute(writes)
+
+    oxdsl = xds_from_zarr(zarr_store)
+
+    writes = xds_to_storage_table(oxdsl, zarr_store)
+
+    oxdsl = dask.compute(oxdsl)[0]
+
+    dask.compute(writes)
+
+    xdsl = dask.compute(xds_from_zarr(zarr_store))[0]
+
+    assert all([xds.equals(oxds) for xds, oxds in zip(xdsl, oxdsl)])
+
+
+def test_storage_parquet(ms, tmp_path_factory):
+
+    parquet_store = tmp_path_factory.mktemp("parquet") / "test.parquet"
+
+    oxdsl = xds_from_ms(ms)
+
+    writes = xds_to_parquet(oxdsl, parquet_store)
+
+    dask.compute(writes)
+
+    oxdsl = xds_from_parquet(parquet_store)
+
+    writes = xds_to_storage_table(oxdsl, parquet_store)
+
+    oxdsl = dask.compute(oxdsl)[0]
+
+    # import ipdb; ipdb.set_trace()
+
+    dask.compute(writes)
+
+    xdsl = dask.compute(xds_from_parquet(parquet_store), scheduler='sync')[0]
+
+    assert all([xds.equals(oxds) for xds, oxds in zip(xdsl, oxdsl)])

--- a/daskms/tests/test_storage.py
+++ b/daskms/tests/test_storage.py
@@ -1,9 +1,16 @@
+import pytest
 import dask
 from daskms import xds_to_storage_table, xds_from_ms
 from daskms.experimental.zarr import xds_from_zarr, xds_to_zarr
 from daskms.experimental.arrow import xds_from_parquet, xds_to_parquet
 
+try:
+    import xarray
+except ImportError:
+    xarray = None
 
+
+@pytest.mark.skipif(xarray is None, reason="Need xarray to check equality.")
 def test_storage_ms(ms):
 
     oxdsl = xds_from_ms(ms)
@@ -19,6 +26,7 @@ def test_storage_ms(ms):
     assert all([xds.equals(oxds) for xds, oxds in zip(xdsl, oxdsl)])
 
 
+@pytest.mark.skipif(xarray is None, reason="Need xarray to check equality.")
 def test_storage_zarr(ms, tmp_path_factory):
 
     zarr_store = tmp_path_factory.mktemp("zarr") / "test.zarr"
@@ -42,6 +50,7 @@ def test_storage_zarr(ms, tmp_path_factory):
     assert all([xds.equals(oxds) for xds, oxds in zip(xdsl, oxdsl)])
 
 
+@pytest.mark.skipif(xarray is None, reason="Need xarray to check equality.")
 def test_storage_parquet(ms, tmp_path_factory):
 
     parquet_store = tmp_path_factory.mktemp("parquet") / "test.parquet"

--- a/daskms/tests/test_storage.py
+++ b/daskms/tests/test_storage.py
@@ -58,8 +58,6 @@ def test_storage_parquet(ms, tmp_path_factory):
 
     oxdsl = dask.compute(oxdsl)[0]
 
-    # import ipdb; ipdb.set_trace()
-
     dask.compute(writes)
 
     xdsl = dask.compute(xds_from_parquet(parquet_store), scheduler='sync')[0]

--- a/daskms/tests/test_utils.py
+++ b/daskms/tests/test_utils.py
@@ -9,7 +9,8 @@ import pytest
 from daskms.utils import (promote_columns,
                           natural_order,
                           table_path_split,
-                          requires)
+                          requires,
+                          filter_kwargs)
 
 
 def test_natural_order():
@@ -78,3 +79,16 @@ def test_requires():
     assert "need bar" in e.value.msg
 
     assert requires("need foo", 1, None)(fn)() == 1
+
+
+def test_sanitize():
+
+    def f(arg0, arg1=None, arg2=None):
+        return
+
+    kwargs = {"arg0": None, "arg1": None, "arg2": None, "arg3": None}
+
+    with pytest.warns(UserWarning):
+        filter_kwargs(f, kwargs)
+
+    assert "arg3" not in kwargs

--- a/daskms/utils.py
+++ b/daskms/utils.py
@@ -5,6 +5,8 @@ import logging
 from pathlib import PurePath, Path
 import re
 import time
+import inspect
+import warnings
 
 from dask.utils import funcname
 # The numpy module may disappear during interpreter shutdown
@@ -210,3 +212,21 @@ def requires(*args):
             return fn
 
     return decorator
+
+
+def filter_kwargs(func, kwargs):
+    """Filters unhandled kwargs and raises appropriate warnings."""
+
+    known_args = inspect.getfullargspec(func).args
+
+    unhandled_kwargs = [k for k in kwargs.keys() if k not in known_args]
+
+    for unhandled_kwarg in unhandled_kwargs:
+        kwargs.pop(unhandled_kwarg)
+
+    if unhandled_kwargs:
+        warnings.warn(
+            f"The following kwargs will be ignored in {func.__name__}: "
+            f"{unhandled_kwargs}.",
+            UserWarning,
+        )


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```

This is still a work in progress, but the basics are there and working. The final step is to make sure that `kwargs` are handled correctly as not all the `xds_to_*` have identical signatures.
