### PR TITLE
Some minor fixes for zarr/conversion functionality.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Fix minor bugs in zarr and conversion functionality. (:pr:`208`)
 * Fix #205 - Add xds_to_storage_table. (:pr:`207`)
 * Fix #187 - add option to rechunk automatically on writes. (:pr:`204`)
 * Fix #118 - raise more informative error. (:pr:`203`)

--- a/daskms/apps/convert.py
+++ b/daskms/apps/convert.py
@@ -305,11 +305,13 @@ def convert_table(args):
         writer = out_fmt.writer()
 
         if isinstance(in_fmt, CasaFormat) and table in NONUNIFORM_SUBTABLES:
-            # Drop any ROWID columns
-            datasets = [ds.drop_vars("ROWID", errors="ignore")
-                        for ds in reader(in_path, group_cols="__row__")]
+            datasets = reader(in_path, group_cols="__row__")
         else:
             datasets = reader(in_path)
+
+        if isinstance(in_fmt, CasaFormat):
+            datasets = [ds.drop_vars("ROWID", errors="ignore")
+                        for ds in datasets]
 
         writes.append(writer(datasets, str(out_path)))
 

--- a/daskms/experimental/utils.py
+++ b/daskms/experimental/utils.py
@@ -33,9 +33,9 @@ def extent_args(dims, chunks):
 
 def column_iterator(variables, columns):
     if columns is None or columns == "ALL":
-        columns = set(variables.array_keys())
+        columns = set(variables.keys())
     else:
-        columns = set(columns) & set(variables.array_keys())
+        columns = set(columns) & set(variables.keys())
 
     for c in columns:
         yield c, variables[c]

--- a/daskms/experimental/utils.py
+++ b/daskms/experimental/utils.py
@@ -87,7 +87,7 @@ def select_vars_and_coords(dataset, columns):
         coord_sel = column_set & coord_names
 
         for dv in data_sel:
-            coord_sel = coord_sel.union(*data_vars[dv].coords.keys())
+            coord_sel = coord_sel.union(set(data_vars[dv].coords.keys()))
 
         ret_data_vars = {col: data_vars[col] for col in data_sel}
         ret_coords = {c: coords[c] for c in coord_sel}

--- a/daskms/experimental/utils.py
+++ b/daskms/experimental/utils.py
@@ -33,11 +33,12 @@ def extent_args(dims, chunks):
 
 def column_iterator(variables, columns):
     if columns is None or columns == "ALL":
-        for k, v in variables.items():
-            yield k, v
+        columns = set(variables.array_keys())
     else:
-        for c in (set(columns) & set(variables.keys())):
-            yield c, variables[c]
+        columns = set(columns) & set(variables.array_keys())
+
+    for c in columns:
+        yield c, variables[c]
 
 
 def promote_columns(columns):

--- a/daskms/experimental/utils.py
+++ b/daskms/experimental/utils.py
@@ -33,12 +33,11 @@ def extent_args(dims, chunks):
 
 def column_iterator(variables, columns):
     if columns is None or columns == "ALL":
-        columns = set(variables.keys())
+        for k, v in variables.items():
+            yield k, v
     else:
-        columns = set(columns) & set(variables.keys())
-
-    for c in columns:
-        yield c, variables[c]
+        for c in (set(columns) & set(variables.keys())):
+            yield c, variables[c]
 
 
 def promote_columns(columns):

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -287,7 +287,11 @@ def xds_to_zarr(xds, store, columns=None, rechunk=False):
 
 
 def zarr_getter(zarray, *extents):
-    return zarray[tuple(slice(start, end) for start, end in extents)]
+    if any([start == end for start, end in extents]):  # Empty slice.
+        shape = [start - end for start, end in extents]
+        return np.empty(shape, dtype=zarray.dtype)
+    else:
+        return zarray[tuple(slice(start, end) for start, end in extents)]
 
 
 def group_sortkey(element):

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -26,6 +26,7 @@ from daskms.fsspec_store import DaskMSStore
 
 try:
     import zarr
+    import zarr.convenience as zc
 except ImportError as e:
     zarr_import_error = e
 else:
@@ -355,7 +356,10 @@ def xds_from_zarr(store, columns=None, chunks=None, **kwargs):
     datasets = []
     numpy_vars = []
 
-    table_group = zarr.open(store.map)[store.table]
+    # NOTE(JSKenyon): Iterating over all the zarr groups/arrays is VERY
+    # expensive if the metadata has not been consolidated.
+    zc.consolidate_metadata(store.map)
+    table_group = zarr.open_consolidated(store.map)[store.table]
 
     for g, (group_name, group) in enumerate(sorted(table_group.groups(),
                                                    key=group_sortkey)):


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
