### PR TITLE
Fix #209 - chunk correctly when reading from parquet.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Fix #209 - chunk correctly when reading from parquet. (:pr:`210`)
 * Fix minor bugs in zarr and conversion functionality. (:pr:`208`)
 * Fix #205 - Add xds_to_storage_table. (:pr:`207`)
 * Fix #187 - add option to rechunk automatically on writes. (:pr:`204`)

--- a/daskms/experimental/arrow/tests/test_parquet.py
+++ b/daskms/experimental/arrow/tests/test_parquet.py
@@ -1,5 +1,5 @@
 import random
-import itertools
+from itertools import chain
 
 import dask
 import dask.array as da
@@ -76,7 +76,11 @@ def test_partition_chunks(row_chunks, user_chunks):
                 (1, (0, 2)), (1, (2, 3)),
                 (2, (0, 1)), (2, (1, 3)), (2, (3, 4))]
 
-    assert partition_chunking(0, row_chunks, [user_chunks]) == expected
+    partition_chunks = partition_chunking(0, row_chunks, [user_chunks])
+
+    obtained = chain.from_iterable([c for c in partition_chunks.values()])
+
+    assert list(obtained) == expected
 
 
 def test_xds_to_parquet_string(tmp_path_factory):
@@ -191,6 +195,6 @@ def test_xds_from_parquet_chunks(ms, parquet_ms, rc):
 
     xdsl = xds_from_parquet(parquet_ms, chunks={'row': rc})
 
-    chunks = itertools.chain.from_iterable([xds.chunks['row'] for xds in xdsl])
+    chunks = chain.from_iterable([xds.chunks['row'] for xds in xdsl])
 
     assert all([c <= rc for c in chunks])

--- a/daskms/tests/test_utils.py
+++ b/daskms/tests/test_utils.py
@@ -81,7 +81,7 @@ def test_requires():
     assert requires("need foo", 1, None)(fn)() == 1
 
 
-def test_sanitize():
+def test_filter_kwargs():
 
     def f(arg0, arg1=None, arg2=None):
         return


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```

This PR should fix #209 by taking into account chunking which spans multiple row groups. I have added tests which check that the requested chunking lines up with the resulting chunking for a number of scenarios (big to small, small to big, equal chunks). The only thing which I am uncertain of is whether or not my approach is distribution safe. The `ParquetFileProxy` is a is a `Multiton` with a `__reduce__` method, so everything works but I will need to keep an eye out for issues in production.