### PR TITLE
Wait for minio to start with greater precision

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Wait for minio to start with greater precision (:pr:`215`)
 * Fix #209 - chunk correctly when reading from parquet. (:pr:`210`)
 * Fix minor bugs in zarr and conversion functionality. (:pr:`208`)
 * Fix #205 - Add xds_to_storage_table. (:pr:`207`)

--- a/daskms/conftest.py
+++ b/daskms/conftest.py
@@ -269,11 +269,13 @@ def minio_server(tmp_path_factory):
 
     # Start the server process and read a line from stdout so that we know
     # it's started
-    ctx = multiprocessing.get_context("spawn")  # noqa
     server_process = Popen(args, shell=False, stdout=PIPE, stderr=PIPE)
-    server_process.stdout.readline()
 
     try:
+        while line := server_process.stdout.readline():
+            if "Documentation: ".encode("utf-8") in line:
+                break
+
         retcode = server_process.poll()
 
         if retcode is not None:


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
