### PR TITLE
Ensure url and table consistency in DaskMSStore

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Ensure url and table consistency in DaskMSStore (:pr:`216`)
 * Wait for minio to start with greater precision (:pr:`215`)
 * Chunk correctly when reading from parquet. (:pr:`210`)
 * Fix minor bugs in zarr and conversion functionality. (:pr:`208`)

--- a/daskms/experimental/arrow/reads.py
+++ b/daskms/experimental/arrow/reads.py
@@ -76,7 +76,7 @@ class ParquetFileProxy(metaclass=Multiton):
             except AttributeError:
                 pass
 
-            sf = self.store.open_file(self.key, "rb")
+            sf = self.store.open(self.key, "rb")
             self._file = file_ = pq.ParquetFile(sf)
             return file_
 

--- a/daskms/experimental/arrow/writes.py
+++ b/daskms/experimental/arrow/writes.py
@@ -91,7 +91,7 @@ class ParquetFragment(metaclass=Multiton):
 
         table = pa.table(table_data, schema=self.schema.to_arrow_schema())
         parquet_filename = self.key / f"{chunk.item()}.parquet"
-        sf = self.store.open_file(parquet_filename, "wb")
+        sf = self.store.open(parquet_filename, "wb")
         pq.write_table(table, sf)
 
         return np.array([True], bool)

--- a/daskms/fsspec_store.py
+++ b/daskms/fsspec_store.py
@@ -111,7 +111,7 @@ class DaskMSStore:
         prefix = f"{self.full_path}{sep}"
         return (self._remove_prefix(p, prefix) for p in paths)
 
-    def open_file(self, key, *args, **kwargs):
+    def open(self, key, *args, **kwargs):
         path = self._extend_path(key)
         return self.fs.open(path, *args, **kwargs)
 

--- a/daskms/fsspec_store.py
+++ b/daskms/fsspec_store.py
@@ -36,7 +36,6 @@ class DaskMSStore:
             self.full_path = path
             self.table = "MAIN"
 
-
     def type(self):
         """
         Returns

--- a/daskms/tests/test_fsspec_store.py
+++ b/daskms/tests/test_fsspec_store.py
@@ -13,7 +13,7 @@ def test_local_store(tmp_path):
     (tmp_path / "bar.txt").write_text(payload)
     (tmp_path / "qux.txt").write_text(payload)
     store = DaskMSStore(str(tmp_path))
-    store.fs.mkdir(f"{store.path}/bob", exist_ok=True)
+    store.fs.mkdir(f"{store.full_path}{store.fs.sep}bob", exist_ok=True)
 
     assert store.map[filename] == payload.encode("utf-8")
 


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
