### PR TITLE
Fix cached_array implementation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Fix cached_array implementation. (:pr:`220`)
 * Use DaskMSStore throughout dask-ms convert (:pr:`218`)
 * Upgrade from deprecated ``visit_Num`` to ``visit_Constant`` (:pr:`217`)
 * Ensure url and table consistency in DaskMSStore (:pr:`216`)

--- a/daskms/optimisation.py
+++ b/daskms/optimisation.py
@@ -56,7 +56,7 @@ class Key(metaclass=KeyMetaClass):
     __str__ = __repr__
 
 
-def cache_entry(cache, key, task):
+def cache_entry(cache, key, *task):
     with cache.lock:
         try:
             return cache.cache[key]
@@ -144,7 +144,7 @@ def cached_array(array, token=None):
     assert len(dsk3) == len(keys)
 
     for k in keys:
-        dsk3[k] = (cache_entry, cache, Key(k), dsk3.pop(k))
+        dsk3[k] = (cache_entry, cache, Key(k), *dsk3.pop(k))
 
     graph = HighLevelGraph.from_collections(array.name, dsk3, [])
 


### PR DESCRIPTION
- [X] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```

Turns out the fix was relatively simple. Dask was getting confused by the embedded task.

Edit: I know you are working on a better solution @sjperkins - just thought this would be interesting for comparison purposes.