### PR TITLE
Don't convert SOURCE subtable

### DIFF
--- a/daskms/apps/convert.py
+++ b/daskms/apps/convert.py
@@ -291,7 +291,7 @@ def convert_table(args):
 
     # Now do the subtables
     for table in list(in_fmt.subtables):
-        if table == "SORTED_TABLE":
+        if table in {"SORTED_TABLE", "SOURCE"}:
             log.warning(f"Ignoring {table}")
             continue
 


### PR DESCRIPTION
The `SOURCE_MODEL` column contains Records aka dictionaries per row which are difficult to model with numpy/dask arrays.


- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
