### PR TITLE
Accept storage_options in dataset read/write methods

### DIFF
--- a/daskms/dask_ms.py
+++ b/daskms/dask_ms.py
@@ -271,7 +271,9 @@ def xds_from_table(table_name, columns=None,
     if isinstance(table_name, DaskMSStore):
         table_name = table_name.casa_path()
     else:
-        table_name = DaskMSStore(table_name).casa_path()
+        storage_opts = kwargs.pop("storage_options", {})
+        store = DaskMSStore(table_name, **storage_opts)
+        table_name = store.casa_path()
 
     columns = promote_columns(columns, [])
     index_cols = promote_columns(index_cols, [])
@@ -324,7 +326,8 @@ def xds_from_ms(ms, columns=None, index_cols=None, group_cols=None, **kwargs):
 
 def xds_from_storage_table(store, **kwargs):
     if not isinstance(store, DaskMSStore):
-        store = DaskMSStore(store)
+        storage_opts = kwargs.pop("storage_options", {})
+        store = DaskMSStore(store, **storage_opts)
 
     typ = store.type()
 
@@ -342,7 +345,8 @@ def xds_from_storage_table(store, **kwargs):
 
 def xds_from_storage_ms(store, **kwargs):
     if not isinstance(store, DaskMSStore):
-        store = DaskMSStore(store)
+        storage_opts = kwargs.pop("storage_options", {})
+        store = DaskMSStore(store, **storage_opts)
 
     typ = store.type()
 
@@ -360,7 +364,8 @@ def xds_from_storage_ms(store, **kwargs):
 
 def xds_to_storage_table(xds, store, **kwargs):
     if not isinstance(store, DaskMSStore):
-        store = DaskMSStore(store)
+        storage_opts = kwargs.pop("storage_options", {})
+        store = DaskMSStore(store, **storage_opts)
 
     typ = store.type()
 

--- a/daskms/experimental/arrow/reads.py
+++ b/daskms/experimental/arrow/reads.py
@@ -212,10 +212,9 @@ def xds_from_parquet(store, columns=None, chunks=None, **kwargs):
 
     if isinstance(store, DaskMSStore):
         pass
-    elif isinstance(store, Path):
-        store = DaskMSStore(f"file://{store}")
-    elif isinstance(store, str):
-        store = DaskMSStore(f"file://{store}")
+    elif isinstance(store, (str, Path)):
+        storage_opts = kwargs.pop("storage_options", {})
+        store = DaskMSStore(f"file://{store}", **storage_opts)
     else:
         raise TypeError(f"store '{store}' must be "
                         f"Path, str or DaskMSStore")

--- a/daskms/experimental/arrow/writes.py
+++ b/daskms/experimental/arrow/writes.py
@@ -101,10 +101,9 @@ class ParquetFragment(metaclass=Multiton):
 def xds_to_parquet(xds, store, columns=None):
     if isinstance(store, DaskMSStore):
         pass
-    elif isinstance(store, Path):
-        store = DaskMSStore(f"file://{store}")
-    elif isinstance(store, str):
-        store = DaskMSStore(f"file://{store}")
+    elif isinstance(store, (str, Path)):
+        storage_opts = kwargs.pop("storage_options", {})
+        store = DaskMSStore(f"file://{store}", **storage_opts)
     else:
         raise TypeError(f"store '{store}' must be "
                         f"Path, str or DaskMSStore")

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -211,7 +211,7 @@ def _gen_writes(variables, chunks, factory, indirect_dims=False):
 
 @requires("pip install dask-ms[zarr] for zarr support",
           zarr_import_error)
-def xds_to_zarr(xds, store, columns=None, rechunk=False):
+def xds_to_zarr(xds, store, columns=None, rechunk=False, **kwargs):
     """
     Stores a dataset of list of datasets defined by `xds` in
     file location `store`.
@@ -229,6 +229,7 @@ def xds_to_zarr(xds, store, columns=None, rechunk=False):
     rechunk : bool
         Controls whether dask arrays should be automatically rechunked to be
         consistent with existing on-disk zarr arrays while writing to disk.
+    **kwargs : optional
 
     Returns
     -------
@@ -237,10 +238,9 @@ def xds_to_zarr(xds, store, columns=None, rechunk=False):
     """
     if isinstance(store, DaskMSStore):
         pass
-    elif isinstance(store, Path):
-        store = DaskMSStore(f"file://{store}")
-    elif isinstance(store, str):
-        store = DaskMSStore(f"file://{store}")
+    elif isinstance(store, (Path, str)):
+        storage_opts = kwargs.pop("storage_options", {})
+        store = DaskMSStore(f"file://{store}", **storage_opts)
     else:
         raise TypeError(f"store '{store}' must be "
                         f"Path, str or DaskMSStore")
@@ -323,6 +323,15 @@ def xds_from_zarr(store, columns=None, chunks=None, **kwargs):
         Dataset(s) representing write operations
     """
 
+    if isinstance(store, DaskMSStore):
+        pass
+    elif isinstance(store, (Path, str)):
+        storage_opts = kwargs.pop("storage_options", {})
+        store = DaskMSStore(f"file://{store}", **storage_opts)
+    else:
+        raise TypeError(f"store '{store}' must be "
+                        f"Path, str or DaskMSStore")
+
     # If any kwargs are added, they should be popped prior to this check.
     if len(kwargs) > 0:
         warnings.warn(
@@ -331,15 +340,6 @@ def xds_from_zarr(store, columns=None, chunks=None, **kwargs):
             UserWarning,
         )
 
-    if isinstance(store, DaskMSStore):
-        pass
-    elif isinstance(store, Path):
-        store = DaskMSStore(f"file://{store}")
-    elif isinstance(store, str):
-        store = DaskMSStore(f"file://{store}")
-    else:
-        raise TypeError(f"store '{store}' must be "
-                        f"Path, str or DaskMSStore")
 
     columns = promote_columns(columns)
 


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
