### PR TITLE
Support loading of storage_options in dask-ms convert

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Support loading of storage_options in dask-ms convert (:pr:`231`)
 * Reintroduce group columns on output CASA format only" (:pr:`230`)
 * Stop converting results returned from DaskMSStore into Path objects (:pr:`229`)
 * Accept storage_options in dataset read/write methods (:pr:`228`)

--- a/daskms/apps/convert.py
+++ b/daskms/apps/convert.py
@@ -58,8 +58,7 @@ class TableFormat(abc.ABC):
         raise NotImplementedError
 
     @staticmethod
-    def from_path(path):
-        store = path if isinstance(path, DaskMSStore) else DaskMSStore(path)
+    def from_store(store):
         typ = store.type()
 
         if typ == "casa":
@@ -272,7 +271,7 @@ NONUNIFORM_SUBTABLES = ["SPECTRAL_WINDOW", "POLARIZATION", "FEED", "SOURCE"]
 
 
 def _check_input_path(input: str):
-    input_path = DaskMSStore(input)
+    input_path = DaskMSStore.from_url_and_kw(input, {})
 
     if not input_path.exists():
         raise ArgumentTypeError(f"{input} is an invalid path.")
@@ -281,7 +280,7 @@ def _check_input_path(input: str):
 
 
 def _check_output_path(output: str):
-    return DaskMSStore(output)
+    return DaskMSStore.from_url_and_kw(output, {})
 
 
 def parse_chunks(chunks: str):
@@ -376,7 +375,7 @@ class Convert(Application):
         return new_datasets
 
     def convert_table(self, args):
-        in_fmt = TableFormat.from_path(args.input)
+        in_fmt = TableFormat.from_store(args.input)
         out_fmt = TableFormat.from_type(args.format)
 
         reader = in_fmt.reader(
@@ -408,7 +407,7 @@ class Convert(Application):
                 continue
 
             in_store = args.input.subtable_store(table)
-            in_fmt = TableFormat.from_path(in_store)
+            in_fmt = TableFormat.from_store(in_store)
             out_store = args.output.subtable_store(table)
             out_fmt = TableFormat.from_type(args.format)
 


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
