### PR TITLE
Minor but possibly breaking changes to DaskMSStore.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Minor DaskMSStore changes to improve URL handling. (:pr:`233`)
 * Support loading of storage_options in dask-ms convert (:pr:`231`)
 * Reintroduce group columns on output CASA format only" (:pr:`230`)
 * Stop converting results returned from DaskMSStore into Path objects (:pr:`229`)

--- a/daskms/experimental/arrow/reads.py
+++ b/daskms/experimental/arrow/reads.py
@@ -228,6 +228,11 @@ def xds_from_parquet(store, columns=None, chunks=None, **kwargs):
     else:
         raise TypeError("chunks must be None or dict or list of dict")
 
+    if store.table:
+        table_root = ""
+    else:
+        table_root = "MAIN"
+
     fragments = list(map(Path, store.rglob("*.parquet")))
     ds_cfg = defaultdict(list)
 
@@ -236,8 +241,8 @@ def xds_from_parquet(store, columns=None, chunks=None, **kwargs):
     partition_schemas = set()
 
     for fragment in fragments:
-        *partitions, parquet_file = fragment.relative_to(store.table).parts
-        fragment = ParquetFileProxy(store, fragment)
+        *partitions, _ = fragment.relative_to(Path(table_root)).parts
+        fragment = ParquetFileProxy(store, str(fragment))
         fragment_meta = fragment.metadata
         metadata = json.loads(fragment_meta.metadata[DASKMS_METADATA.encode()])
         partition_meta = metadata[DASKMS_PARTITION_KEY]

--- a/daskms/experimental/arrow/reads.py
+++ b/daskms/experimental/arrow/reads.py
@@ -228,10 +228,7 @@ def xds_from_parquet(store, columns=None, chunks=None, **kwargs):
     else:
         raise TypeError("chunks must be None or dict or list of dict")
 
-    if store.table:
-        table_root = ""
-    else:
-        table_root = "MAIN"
+    table_path = "" if store.table else "MAIN"
 
     fragments = list(map(Path, store.rglob("*.parquet")))
     ds_cfg = defaultdict(list)
@@ -241,7 +238,7 @@ def xds_from_parquet(store, columns=None, chunks=None, **kwargs):
     partition_schemas = set()
 
     for fragment in fragments:
-        *partitions, _ = fragment.relative_to(Path(table_root)).parts
+        *partitions, _ = fragment.relative_to(Path(table_path)).parts
         fragment = ParquetFileProxy(store, str(fragment))
         fragment_meta = fragment.metadata
         metadata = json.loads(fragment_meta.metadata[DASKMS_METADATA.encode()])

--- a/daskms/experimental/arrow/writes.py
+++ b/daskms/experimental/arrow/writes.py
@@ -49,11 +49,8 @@ class ParquetFragment:
         else:
             partition = tuple((p, schema.attrs[p]) for p, _ in partition)
 
-        key = Path(key)
-
         # Add the partitioning to the path
-        for field, value in partition:
-            key /= f"{field}={value}"
+        key = store.join([f"{f}={v}" for f, v in partition])
 
         self.dataset_id = dataset_id
         self.store = store
@@ -67,8 +64,14 @@ class ParquetFragment:
                                   self.schema, self.dataset_id))
 
     def write(self, chunk, *data):
+
+        if self.store.table:
+            table_path = self.key
+        else:
+            table_path = self.store.join(["MAIN", self.key])
+
         with self.lock:
-            self.store.makedirs(self.key, exist_ok=True)
+            self.store.makedirs(table_path, exist_ok=True)
 
         table_data = {}
 
@@ -90,9 +93,11 @@ class ParquetFragment:
             table_data[column] = pa_data
 
         table = pa.table(table_data, schema=self.schema.to_arrow_schema())
-        parquet_filename = self.key / f"{chunk.item()}.parquet"
-        sf = self.store.open(parquet_filename, "wb")
-        pq.write_table(table, sf)
+        parts = [table_path, f"{chunk.item()}.parquet"]
+        parquet_filename = self.store.join(parts)
+
+        with self.store.open(parquet_filename, "wb") as sf:
+            pq.write_table(table, sf)
 
         return np.array([True], bool)
 

--- a/daskms/experimental/arrow/writes.py
+++ b/daskms/experimental/arrow/writes.py
@@ -65,10 +65,8 @@ class ParquetFragment:
 
     def write(self, chunk, *data):
 
-        if self.store.table:
-            table_path = self.key
-        else:
-            table_path = self.store.join(["MAIN", self.key])
+        table_path = (self.key if self.store.table else
+                      self.store.join(["MAIN", self.key]))
 
         with self.lock:
             self.store.makedirs(table_path, exist_ok=True)

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -103,10 +103,10 @@ def prepare_zarr_group(dataset_id, dataset, store):
         # Create, must not exist
         group = zarr.open_group(store=store.map, mode="w-")
 
-    table_name = store.table if store.table else "MAIN"
+    table_path = store.table if store.table else "MAIN"
 
-    group_name = f"{table_name}_{dataset_id}"
-    ds_group = group.require_group(table_name).require_group(group_name)
+    group_name = f"{table_path}_{dataset_id}"
+    ds_group = group.require_group(table_path).require_group(group_name)
 
     schema = DatasetSchema.from_dataset(dataset)
     schema_chunks = schema.chunks
@@ -364,8 +364,8 @@ def xds_from_zarr(store, columns=None, chunks=None, **kwargs):
     # NOTE(JSKenyon): Iterating over all the zarr groups/arrays is VERY
     # expensive if the metadata has not been consolidated.
     zc.consolidate_metadata(store.map)
-    table_name = store.table if store.table else "MAIN"
-    table_group = zarr.open_consolidated(store.map)[table_name]
+    table_path = store.table if store.table else "MAIN"
+    table_group = zarr.open_consolidated(store.map)[table_path]
 
     for g, (group_name, group) in enumerate(sorted(table_group.groups(),
                                                    key=group_sortkey)):

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -103,8 +103,10 @@ def prepare_zarr_group(dataset_id, dataset, store):
         # Create, must not exist
         group = zarr.open_group(store=store.map, mode="w-")
 
-    group_name = f"{store.table}_{dataset_id}"
-    ds_group = group.require_group(store.table).require_group(group_name)
+    table_name = store.table if store.table else "MAIN"
+
+    group_name = f"{table_name}_{dataset_id}"
+    ds_group = group.require_group(table_name).require_group(group_name)
 
     schema = DatasetSchema.from_dataset(dataset)
     schema_chunks = schema.chunks
@@ -362,7 +364,8 @@ def xds_from_zarr(store, columns=None, chunks=None, **kwargs):
     # NOTE(JSKenyon): Iterating over all the zarr groups/arrays is VERY
     # expensive if the metadata has not been consolidated.
     zc.consolidate_metadata(store.map)
-    table_group = zarr.open_consolidated(store.map)[store.table]
+    table_name = store.table if store.table else "MAIN"
+    table_group = zarr.open_consolidated(store.map)[table_name]
 
     for g, (group_name, group) in enumerate(sorted(table_group.groups(),
                                                    key=group_sortkey)):

--- a/daskms/fsspec_store.py
+++ b/daskms/fsspec_store.py
@@ -29,8 +29,7 @@ class DaskMSStore:
 
         full_url = self.fs.unstrip_protocol(self.map.root)
         self.storage_options = storage_options
-        protocol, path = fsspec.core.split_protocol(full_url)
-        self.protocol = "file" if protocol is None else protocol
+        self.protocol, path = fsspec.core.split_protocol(full_url)
 
         if table:
             self.canonical_path = f"{path}::{table}"

--- a/daskms/fsspec_store.py
+++ b/daskms/fsspec_store.py
@@ -39,8 +39,6 @@ class DaskMSStore:
         else:
             self.canonical_path = path
             self.full_path = path
-            # NOTE (JSKenyon): This may be the cause of our problems when
-            # attempting to access a zarr store without the :: notation.
             self.table = None
 
     def type(self):
@@ -130,7 +128,7 @@ class DaskMSStore:
         return self.map[key]
 
     def _extend_path(self, path=""):
-        return self.join([self.full_path, path])
+        return self.join([self.full_path, path]) if path else self.full_path
 
     def exists(self, path=""):
         return self.fs.exists(self._extend_path(path))

--- a/daskms/fsspec_store.py
+++ b/daskms/fsspec_store.py
@@ -26,8 +26,10 @@ class DaskMSStore:
 
         self.map = fsspec.get_mapper(url, **storage_options)
         self.fs = self.map.fs
+
+        full_url = self.fs.unstrip_protocol(self.map.root)
         self.storage_options = storage_options
-        protocol, path = fsspec.core.split_protocol(url)
+        protocol, path = fsspec.core.split_protocol(full_url)
         self.protocol = "file" if protocol is None else protocol
 
         if table:

--- a/daskms/tests/test_fsspec_store.py
+++ b/daskms/tests/test_fsspec_store.py
@@ -37,7 +37,7 @@ def test_store_main_access(tmp_path_factory):
     assert store.url == f"file://{store_dir}"
     assert store.full_path == str(store_dir)
     assert store.canonical_path == str(store_dir)
-    assert store.table == "MAIN"
+    assert store.table is None
 
     with store.open("foo.txt", "w") as f:
         f.write("How now brown cow")


### PR DESCRIPTION
Intention is to make recovering absolute paths simpler.

- [X] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
