### PR TITLE
Configure custom storage options if url matches configured prefix

### DIFF
--- a/daskms/apps/convert.py
+++ b/daskms/apps/convert.py
@@ -271,7 +271,7 @@ NONUNIFORM_SUBTABLES = ["SPECTRAL_WINDOW", "POLARIZATION", "FEED", "SOURCE"]
 
 
 def _check_input_path(input: str):
-    input_path = DaskMSStore.from_url_and_kw(input, {})
+    input_path = DaskMSStore(input)
 
     if not input_path.exists():
         raise ArgumentTypeError(f"{input} is an invalid path.")
@@ -280,7 +280,7 @@ def _check_input_path(input: str):
 
 
 def _check_output_path(output: str):
-    return DaskMSStore.from_url_and_kw(output, {})
+    return DaskMSStore(output)
 
 
 def parse_chunks(chunks: str):

--- a/daskms/config.py
+++ b/daskms/config.py
@@ -1,0 +1,3 @@
+from donfig import Config
+
+config = Config("dask-ms")

--- a/daskms/dask_ms.py
+++ b/daskms/dask_ms.py
@@ -271,7 +271,7 @@ def xds_from_table(table_name, columns=None,
     if isinstance(table_name, DaskMSStore):
         table_name = table_name.casa_path()
     else:
-        store = DaskMSStore.from_url_and_kw(table_name, kwargs)
+        store = DaskMSStore(table_name, **kwargs.pop("storage_options", {}))
         table_name = store.casa_path()
 
     columns = promote_columns(columns, [])
@@ -325,7 +325,7 @@ def xds_from_ms(ms, columns=None, index_cols=None, group_cols=None, **kwargs):
 
 def xds_from_storage_table(store, **kwargs):
     if not isinstance(store, DaskMSStore):
-        store = DaskMSStore.from_url_and_kw(store, kwargs)
+        store = DaskMSStore(store, **kwargs.pop("storage_options", {}))
 
     typ = store.type()
 
@@ -343,7 +343,7 @@ def xds_from_storage_table(store, **kwargs):
 
 def xds_from_storage_ms(store, **kwargs):
     if not isinstance(store, DaskMSStore):
-        store = DaskMSStore.from_url_and_kw(store, kwargs)
+        store = DaskMSStore(store, **kwargs.pop("storage_options", {}))
 
     typ = store.type()
 
@@ -361,7 +361,7 @@ def xds_from_storage_ms(store, **kwargs):
 
 def xds_to_storage_table(xds, store, **kwargs):
     if not isinstance(store, DaskMSStore):
-        store = DaskMSStore.from_url_and_kw(store, kwargs)
+        store = DaskMSStore(store, **kwargs.pop("storage_options", {}))
 
     typ = store.type()
 

--- a/daskms/experimental/arrow/reads.py
+++ b/daskms/experimental/arrow/reads.py
@@ -204,7 +204,7 @@ def xds_from_parquet(store, columns=None, chunks=None, **kwargs):
     if isinstance(store, DaskMSStore):
         pass
     elif isinstance(store, (str, Path)):
-        store = DaskMSStore.from_url_and_kw(f"{store}", kwargs)
+        store = DaskMSStore(f"{store}", **kwargs.pop("storage_options", {}))
     else:
         raise TypeError(f"store '{store}' must be "
                         f"Path, str or DaskMSStore")

--- a/daskms/experimental/arrow/writes.py
+++ b/daskms/experimental/arrow/writes.py
@@ -105,7 +105,7 @@ def xds_to_parquet(xds, store, columns=None, **kwargs):
     if isinstance(store, DaskMSStore):
         pass
     elif isinstance(store, (str, Path)):
-        store = DaskMSStore.from_url_and_kw(f"{store}", kwargs)
+        store = DaskMSStore(f"{store}", **kwargs.pop("storage_options", {}))
     else:
         raise TypeError(f"store '{store}' must be "
                         f"Path, str or DaskMSStore")

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -241,7 +241,7 @@ def xds_to_zarr(xds, store, columns=None, rechunk=False, **kwargs):
     if isinstance(store, DaskMSStore):
         pass
     elif isinstance(store, (Path, str)):
-        store = DaskMSStore.from_url_and_kw(f"{store}", kwargs)
+        store = DaskMSStore(f"{store}", **kwargs.pop("storage_options", {}))
     else:
         raise TypeError(f"store '{store}' must be "
                         f"Path, str or DaskMSStore")
@@ -334,7 +334,7 @@ def xds_from_zarr(store, columns=None, chunks=None, **kwargs):
     if isinstance(store, DaskMSStore):
         pass
     elif isinstance(store, (Path, str)):
-        store = DaskMSStore.from_url_and_kw(f"{store}", kwargs)
+        store = DaskMSStore(f"{store}", **kwargs.pop("storage_options", {}))
     else:
         raise TypeError(f"store '{store}' must be "
                         f"Path, str or DaskMSStore")

--- a/daskms/fsspec_store.py
+++ b/daskms/fsspec_store.py
@@ -1,7 +1,8 @@
-from pathlib import Path, PurePath
+from pathlib import PurePath
 
 import fsspec
 
+from daskms.config import config
 from daskms.utils import freeze
 
 
@@ -12,6 +13,12 @@ class DaskMSStore:
             url = str(url)
 
         bits = url.split("::", 1)
+
+        if not storage_options:
+            for prefix, overrides in config.get("storage_options", {}).items():
+                if url.startswith(prefix):
+                    assert isinstance(overrides, dict)
+                    storage_options = overrides
 
         if len(bits) == 1:
             url = bits[0]
@@ -84,25 +91,6 @@ class DaskMSStore:
     @staticmethod
     def from_reduce_args(url, storage_options):
         return DaskMSStore(url, **storage_options)
-
-    @staticmethod
-    def from_url_and_kw(url, kw):
-        if opts := kw.pop("storage_options", None):
-            pass
-        else:
-            import json
-            from appdirs import AppDirs
-
-            path = Path(AppDirs("dask-ms").user_config_dir)
-            path = path / "storage_options.json"
-
-            if not path.exists():
-                opts = {}
-            else:
-                with open(path, "r") as f:
-                    opts = json.loads(f.read())
-
-        return DaskMSStore(url, **opts)
 
     def __eq__(self, other):
         return (isinstance(other, DaskMSStore) and

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ extras_require["complete"] = set(
 install_requires = [
     "appdirs",
     "dask[array] >= 2.2.0",
+    "donfig"
 ]
 
 # ==================


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
