### PR TITLE
Fail if ROWID shape and chunks don't match associated dataset arrays

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,9 +2,12 @@
 History
 =======
 
+X.Y.Z (YYYY-MM-DD)
+------------------
+* Fail if ROWID dimensions don't match associated dataset arrays (:pr:`239`)
+
 0.2.11 (2022-07-27)
 -------------------
-* Fail if ROWID dimensions don't match associated dataset arrays (:pr:`239`)
 * Improve chunking in xds_to_zarr when rechunk==True. (:pr:`236`)
 * Assign custom fsspec storage options from url match in yaml configuration files. (:pr:`237`)
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.2.11 (2022-07-27)
 -------------------
+* Fail if ROWID dimensions don't match associated dataset arrays (:pr:`239`)
 * Improve chunking in xds_to_zarr when rechunk==True. (:pr:`236`)
 * Assign custom fsspec storage options from url match in yaml configuration files. (:pr:`237`)
 

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -313,10 +313,9 @@ def test_mismatched_rowid(ms):
 
     # NOTE: Remove this line to make this test pass.
     xds = xdsl[0]
-    xds = xds.assign_coords({
+    xds = xds.assign_coords(**{
         "ROWID": (("row",), da.arange(xds.dims["row"], chunks=2))
     })
-    xds = xds.rename({"DATA": "BROKEN_DATA"})
 
     with pytest.raises(ValueError, match="ROWID shape and chunking"):
-        xds_to_table(xds, ms, columns=["BROKEN_DATA"])
+        xds_to_table(xds, ms, columns=["DATA"])

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -317,5 +317,5 @@ def test_mismatched_rowid(ms):
         "ROWID": (("row",), da.arange(xds.dims["row"], chunks=2))
     })
 
-    with pytest.raises(ValueError, match="ROWID shape and chunking"):
+    with pytest.raises(ValueError, match="ROWID shape and/or chunking"):
         xds_to_table(xds, ms, columns=["DATA"])

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -624,6 +624,11 @@ def _write_datasets(table, table_proxy, datasets, columns, descriptor,
 
             inlinable_arrays = [row_order]
 
+            if (row_order.shape[0] != array.shape[0] or
+                    row_order.chunks[0] != array.chunks[0]):
+                raise ValueError(f"ROWID shape and chunking does not "
+                                 f"match that of {column}")
+
             if not all(len(c) == 1 for c in array.chunks[1:]):
                 # Add extent arrays
                 for d, c in zip(full_dims[1:], array.chunks[1:]):

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -626,8 +626,8 @@ def _write_datasets(table, table_proxy, datasets, columns, descriptor,
 
             if (row_order.shape[0] != array.shape[0] or
                     row_order.chunks[0] != array.chunks[0]):
-                raise ValueError(f"ROWID shape and chunking does not "
-                                 f"match that of {column}")
+                raise ValueError(f"ROWID shape and/or chunking does "
+                                 f"not match that of {column}")
 
             if not all(len(c) == 1 for c in array.chunks[1:]):
                 # Add extent arrays


### PR DESCRIPTION
Closes #238 

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
