### PR TITLE
Pin flake8 >= 4.0.0, < 5.0.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+X.Y.Z (YYYY-MM-DD)
+------------------
+* Pin flake8 to >= 4.0.0 and < 5.0.0 (:pr:`240`)
+
 0.2.11 (2022-07-27)
 -------------------
 * Improve chunking in xds_to_zarr when rechunk==True. (:pr:`236`)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {
     "xarray": ["xarray > 0.12.0"],
     "zarr": ["zarr >= 2.6.1"],
     "s3": ["s3fs"],
-    "testing": ["minio", "pytest", "pytest-flake8 >= 1.0.6"],
+    "testing": ["minio", "pytest", "pytest-flake8 >= 1.0.6", "flake8 >= 4.0.0, < 5.0.0"],
 }
 
 extras_require["complete"] = set(


### PR DESCRIPTION
Temporary workaround for tholo/pytest-flake8#87

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
