### PR TITLE
Consolidate zarr metadata when writing

### DIFF
--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -375,12 +375,13 @@ def xds_from_zarr(store, columns=None, chunks=None, **kwargs):
 
     datasets = []
     numpy_vars = []
+    table_path = store.table if store.table else "MAIN"
 
     # NOTE(JSKenyon): Iterating over all the zarr groups/arrays is VERY
     # expensive if the metadata has not been consolidated.
-    zc.consolidate_metadata(store.map)
-    table_path = store.table if store.table else "MAIN"
-    table_group = zarr.open_consolidated(store.map)[table_path]
+    store_map = store.fs.get_mapper(f"{store.full_path}/{table_path}")
+    zc.consolidate_metadata(store_map)
+    table_group = zarr.open_consolidated(store_map)
 
     for g, (group_name, group) in enumerate(sorted(table_group.groups(),
                                                    key=group_sortkey)):

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -379,7 +379,7 @@ def xds_from_zarr(store, columns=None, chunks=None, **kwargs):
 
     # NOTE(JSKenyon): Iterating over all the zarr groups/arrays is VERY
     # expensive if the metadata has not been consolidated.
-    store_map = store.fs.get_mapper(f"{store.full_path}/{table_path}")
+    store_map = store.fs.get_mapper(f"{store.root}{store.fs.sep}{table_path}")
     zc.consolidate_metadata(store_map)
     table_group = zarr.open_consolidated(store_map)
 

--- a/daskms/fsspec_store.py
+++ b/daskms/fsspec_store.py
@@ -37,15 +37,15 @@ class DaskMSStore:
 
         full_url = self.fs.unstrip_protocol(self.map.root)
         self.storage_options = storage_options
-        self.protocol, path = fsspec.core.split_protocol(full_url)
+        self.protocol, self.root = fsspec.core.split_protocol(full_url)
 
         if table:
-            self.canonical_path = f"{path}::{table}"
-            self.full_path = f"{path}{self.fs.sep}{table}"
+            self.canonical_path = f"{self.root}::{table}"
+            self.full_path = f"{self.root}{self.fs.sep}{table}"
             self.table = table
         else:
-            self.canonical_path = path
-            self.full_path = path
+            self.canonical_path = self.root
+            self.full_path = self.root
             self.table = None
 
     def type(self):


### PR DESCRIPTION
Closes #242 

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
