### PR TITLE
Fail if zarr chunks exceed 2GB

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Fail if zarr chunks exceed 2GB (:pr:`247`)
 * Add a ``--exclude`` argument to ``dask-ms convert`` that allows
   columns to be excluded during conversion (:pr:`246`).
 * Make ``--output`` a required ``dask-ms convert`` argument (:pr:`245`).

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -1,5 +1,4 @@
 from functools import reduce
-from itertools import product
 from operator import mul
 from pathlib import Path
 
@@ -85,23 +84,22 @@ def create_array(ds_group, column, column_schema,
 
     zchunks = zarr_chunks(column, column_schema.dims, chunks)
 
-    for chunk in product(zchunks):
-        if column_schema.dtype == object:
-            if reduce(mul, chunk, 32) > 2**(32 - 1):
-                raise ValueError(
-                    f"Column {column} has an object dtype. "
-                    f"Given an estimate of 32 bytes per entry "
-                    f"the chunk of dimensions {chunk}"
-                    f"may exceed zarr's 2GiB chunk limit"
-                )
-        else:
-            size = np.dtype(column_schema.dtype).itemsize
-            if reduce(mul, chunk, size) > 2**(32 - 1):
-                raise ValueError(
-                    f"Column {column} has a chunk of "
-                    f"dimension {chunk} that will exceed "
-                    f"zarr's 2GiB chunk limit"
-                )
+    if column_schema.dtype == object:
+        if reduce(mul, zchunks, 32) >= 2**(32 - 1):
+            raise ValueError(
+                f"Column {column} has an object dtype. "
+                f"Given an estimate of 32 bytes per entry "
+                f"the chunk of dimensions {zchunks}"
+                f"may exceed zarr's 2GiB chunk limit"
+            )
+    else:
+        size = np.dtype(column_schema.dtype).itemsize
+        if reduce(mul, zchunks, size) >= 2**(32 - 1):
+            raise ValueError(
+                f"Column {column} has a chunk of "
+                f"dimension {zchunks} that will exceed "
+                f"zarr's 2GiB chunk limit"
+            )
 
     array = ds_group.require_dataset(column, column_schema.shape,
                                      chunks=zchunks,

--- a/daskms/experimental/zarr/tests/test_zarr.py
+++ b/daskms/experimental/zarr/tests/test_zarr.py
@@ -373,7 +373,7 @@ def test_add_datavars(ms, tmp_path_factory, prechunking, postchunking):
                 for ds, cds in zip(augmented_datasets, chunked_datasets)])
 
 
-def test_zarr_2gb_limit(ms, tmp_path_factory):
+def test_zarr_2gb_limit(tmp_path_factory):
     store = tmp_path_factory.mktemp("zarr_store")
 
     chunk = (1024, 1024, 1024)

--- a/daskms/experimental/zarr/tests/test_zarr.py
+++ b/daskms/experimental/zarr/tests/test_zarr.py
@@ -371,3 +371,24 @@ def test_add_datavars(ms, tmp_path_factory, prechunking, postchunking):
 
     assert all([ds.DUMMY.chunks == cds.DATA.chunks
                 for ds, cds in zip(augmented_datasets, chunked_datasets)])
+
+
+def test_zarr_2gb_limit(ms, tmp_path_factory):
+    store = tmp_path_factory.mktemp("zarr_store")
+
+    chunk = (1024, 1024, 1024)
+    datasets = Dataset({
+        "DATA": (("x", "y", "z"),
+                 da.zeros(chunk, chunks=chunk, dtype=np.uint16))
+    })
+
+    with pytest.raises(ValueError, match="2GiB chunk limit"):
+        xds_to_zarr(datasets, store)
+
+    chunk = (1024, 1024, 999)
+    datasets = Dataset({
+        "DATA": (("x", "y", "z"),
+                 da.zeros(chunk, chunks=chunk, dtype=np.uint16))
+    })
+
+    xds_to_zarr(datasets, store)


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
