### PR TITLE
Don't force convert lists to tuples when decoding attributes

### DIFF
--- a/daskms/dataset_schema.py
+++ b/daskms/dataset_schema.py
@@ -53,7 +53,7 @@ def encode_attr(arg):
 
 def decode_attr(arg):
     if isinstance(arg, (tuple, list)):
-        return tuple(map(decode_attr, arg))
+        return type(arg)(map(decode_attr, arg))
     elif isinstance(arg, set):
         return set(map(decode_attr, arg))
     elif isinstance(arg, dict):


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
