### PR TITLE
Possible fix for #254 - be tolerant of nan chunks.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Fix for nan chunks/dims breaking writes (:pr:`255`)
 * Fix minio deb download URL (:pr:`257`)
 * Apply black to the code base (:pr:`252`)
 * Manage dask-ms with python poetry (:pr:`250`)

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -644,21 +644,17 @@ def _write_datasets(
 
             inlinable_arrays = [row_order]
 
-            if np.isnan(row_order.shape[0]):  # Dealing with nan chunks/dims.
-                if not (
-                    np.isnan(row_order.shape[0]) == np.isnan(array.shape[0])
-                    and len(row_order.chunks[0]) == len(array.chunks[0])
-                ):
-                    raise ValueError(
-                        f"ROWID shape and/or chunking does "
-                        f"not match that of {column}"
-                    )
-            else:
-                if (
-                    row_order.shape[0] != array.shape[0]
-                    or row_order.chunks[0] != array.chunks[0]
-                ):
-                    raise ValueError(
+            import ipdb; ipdb.set_trace()
+
+            if not (
+                np.isnan(row_order.shape[0]) if np.isnan(array.shape[0])
+                else row_order.shape[0] == array.shape[0]
+                and all(
+                    np.isnan(a) if np.isnan(b) else a == b
+                    for a, b in zip(row_order.chunks[0],array.chunks[0])
+                )
+            ):
+                raise ValueError(
                         f"ROWID shape and/or chunking does "
                         f"not match that of {column}"
                     )

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -8,7 +8,6 @@ from daskms.optimisation import cached_array, inlined_array
 from dask.highlevelgraph import HighLevelGraph
 import numpy as np
 import pyrap.tables as pt
-from math import isnan
 
 from daskms.columns import dim_extents_array
 from daskms.constants import DASKMS_PARTITION_KEY
@@ -645,9 +644,9 @@ def _write_datasets(
 
             inlinable_arrays = [row_order]
 
-            if isnan(row_order.shape[0]):  # Dealing with nan chunks/dims.
+            if np.isnan(row_order.shape[0]):  # Dealing with nan chunks/dims.
                 if not (
-                    isnan(row_order.shape[0]) == isnan(array.shape[0])
+                    np.isnan(row_order.shape[0]) == np.isnan(array.shape[0])
                     and len(row_order.chunks[0]) == len(array.chunks[0])
                 ):
                     raise ValueError(

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -645,7 +645,8 @@ def _write_datasets(
             inlinable_arrays = [row_order]
 
             if not (
-                np.isnan(row_order.shape[0]) if np.isnan(array.shape[0])
+                np.isnan(row_order.shape[0])
+                if np.isnan(array.shape[0])
                 else row_order.shape[0] == array.shape[0]
                 and all(
                     np.isnan(a) if np.isnan(b) else a == b
@@ -653,8 +654,7 @@ def _write_datasets(
                 )
             ):
                 raise ValueError(
-                    f"ROWID shape and/or chunking does "
-                    f"not match that of {column}"
+                    f"ROWID shape and/or chunking does not match that of {column}"
                 )
 
             if not all(len(c) == 1 for c in array.chunks[1:]):

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -644,20 +644,18 @@ def _write_datasets(
 
             inlinable_arrays = [row_order]
 
-            import ipdb; ipdb.set_trace()
-
             if not (
                 np.isnan(row_order.shape[0]) if np.isnan(array.shape[0])
                 else row_order.shape[0] == array.shape[0]
                 and all(
                     np.isnan(a) if np.isnan(b) else a == b
-                    for a, b in zip(row_order.chunks[0],array.chunks[0])
+                    for a, b in zip(row_order.chunks[0], array.chunks[0])
                 )
             ):
                 raise ValueError(
-                        f"ROWID shape and/or chunking does "
-                        f"not match that of {column}"
-                    )
+                    f"ROWID shape and/or chunking does "
+                    f"not match that of {column}"
+                )
 
             if not all(len(c) == 1 for c in array.chunks[1:]):
                 # Add extent arrays

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -651,7 +651,8 @@ def _write_datasets(
                     and len(row_order.chunks[0]) == len(array.chunks[0])
                 ):
                     raise ValueError(
-                        f"ROWID shape and/or chunking does " f"not match that of {column}"
+                        f"ROWID shape and/or chunking does "
+                        f"not match that of {column}"
                     )
             else:
                 if (
@@ -659,7 +660,8 @@ def _write_datasets(
                     or row_order.chunks[0] != array.chunks[0]
                 ):
                     raise ValueError(
-                        f"ROWID shape and/or chunking does " f"not match that of {column}"
+                        f"ROWID shape and/or chunking does "
+                        f"not match that of {column}"
                     )
 
             if not all(len(c) == 1 for c in array.chunks[1:]):


### PR DESCRIPTION
- [X] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
