### PR TITLE
Fail on reads if non-existent or invalid store type found

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+X.Y.Z (YYYY-MM-DD)
+------------------
+* Fail on reads if non-existent or invalid store type found (:pr:`259`)
+
 0.2.14 (2022-10-04)
 -------------------
 * Fix for nan chunks/dims breaking writes (:pr:`255`)

--- a/daskms/experimental/arrow/reads.py
+++ b/daskms/experimental/arrow/reads.py
@@ -216,6 +216,8 @@ def xds_from_parquet(store, columns=None, chunks=None, **kwargs):
     else:
         raise TypeError(f"store '{store}' must be " f"Path, str or DaskMSStore")
 
+    store.assert_type("parquet")
+
     # If any kwargs are added, they should be popped prior to this check.
     if len(kwargs) > 0:
         warnings.warn(

--- a/daskms/experimental/arrow/tests/test_parquet.py
+++ b/daskms/experimental/arrow/tests/test_parquet.py
@@ -210,3 +210,10 @@ def test_xds_from_parquet_chunks(ms, parquet_ms, rc):
     chunks = chain.from_iterable([xds.chunks["row"] for xds in xdsl])
 
     assert all([c <= rc for c in chunks])
+
+
+def test_xds_from_parquet_assert_on_empty_store(tmp_path_factory):
+    path = tmp_path_factory.mktemp("parquet_store") / "test.parquet"
+
+    with pytest.raises(AssertionError, match="Unable to infer table type"):
+        xds_from_parquet(path)

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -387,6 +387,8 @@ def xds_from_zarr(store, columns=None, chunks=None, consolidated=True, **kwargs)
     else:
         raise TypeError(f"store '{store}' must be " f"Path, str or DaskMSStore")
 
+    store.assert_type("zarr")
+
     # If any kwargs are added, they should be popped prior to this check.
     if len(kwargs) > 0:
         warnings.warn(

--- a/daskms/experimental/zarr/tests/test_zarr.py
+++ b/daskms/experimental/zarr/tests/test_zarr.py
@@ -404,3 +404,10 @@ def test_zarr_2gb_limit(tmp_path_factory):
     )
 
     xds_to_zarr(datasets, store)
+
+
+def test_xds_from_zarr_assert_on_empty_store(tmp_path_factory, ms):
+    path = tmp_path_factory.mktemp("zarr_store") / "test.zarr"
+
+    with pytest.raises(AssertionError, match="Unable to infer table type"):
+        xds_from_zarr(path)


### PR DESCRIPTION
Closes #258 

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
