### PR TITLE
xds_from_zarr should always open zarr groups in read mode

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* xds_from_zarr should always open zarr groups in read mode (:pr:`262`)
 * Fail on reads if non-existent or invalid store type found (:pr:`259`, :pr:`260`)
 
 0.2.14 (2022-10-04)

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -416,13 +416,11 @@ def xds_from_zarr(store, columns=None, chunks=None, consolidated=True, **kwargs)
     store_map = store.fs.get_mapper(f"{store.root}{store.fs.sep}{table_path}")
 
     try:
-        table_group = zarr.open_consolidated(store_map)
+        table_group = zarr.open_consolidated(store_map, mode="r")
     except KeyError:
-        table_group = zarr.open_group(store_map)
+        table_group = zarr.open_group(store_map, mode="r")
 
-    for g, (group_name, group) in enumerate(
-        sorted(table_group.groups(), key=group_sortkey)
-    ):
+    for g, (_, group) in enumerate(sorted(table_group.groups(), key=group_sortkey)):
         group_attrs = decode_attr(dict(group.attrs))
         dask_ms_attrs = group_attrs.pop(DASKMS_ATTR_KEY)
         natural_chunks = dask_ms_attrs["chunks"]


### PR DESCRIPTION
- Closes #261 

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
