### PR TITLE
Support --taql-where for Measurement Sets in dask-ms convert

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Support --taql-where for Measurement Sets in dask-ms convert (:pr:`264`)
 * xds_from_zarr should always open zarr groups in read mode (:pr:`262`)
 * Fail on reads if non-existent or invalid store type found (:pr:`259`, :pr:`260`)
 

--- a/daskms/apps/convert.py
+++ b/daskms/apps/convert.py
@@ -211,7 +211,7 @@ class ZarrFormat(BaseTableFormat):
         return self._subtables
 
     def reader(self, **kw):
-        for arg in ("group_columns", "index_columns", "taql_where"):
+        for arg in Convert.CASA_INPUT_ONLY_ARGS:
             if kw.pop(arg, False):
                 raise ValueError(f'"{arg}" is not supported for zarr inputs')
 
@@ -251,7 +251,7 @@ class ParquetFormat(BaseTableFormat):
         return self._subtables
 
     def reader(self, **kw):
-        for arg in ("group_columns", "index_columns", "taql_where"):
+        for arg in Convert.CASA_INPUT_ONLY_ARGS:
             if kw.pop(arg, False):
                 raise ValueError(f'"{arg}" is not supported for parquet inputs')
 
@@ -315,6 +315,7 @@ def parse_chunks(chunks: str):
 
 class Convert(Application):
     TABLE_KEYWORD_PREFIX = "Table: "
+    CASA_INPUT_ONLY_ARGS = ("group_columns", "index_columns", "taql_where")
 
     def __init__(self, args, log):
         self.log = log

--- a/daskms/apps/convert.py
+++ b/daskms/apps/convert.py
@@ -158,12 +158,16 @@ class CasaFormat(BaseTableFormat):
         try:
             group_cols = kw.pop("group_columns", None)
             index_cols = kw.pop("index_columns", None)
+            taql_where = kw.pop("taql_where", "")
 
             if self.is_measurement_set():
                 from daskms import xds_from_ms
 
                 return partial(
-                    xds_from_ms, group_cols=group_cols, index_cols=index_cols
+                    xds_from_ms,
+                    group_cols=group_cols,
+                    index_cols=index_cols,
+                    taql_where=taql_where,
                 )
             else:
                 from daskms import xds_from_table
@@ -207,13 +211,10 @@ class ZarrFormat(BaseTableFormat):
         return self._subtables
 
     def reader(self, **kw):
-        group_columns = kw.pop("group_columns", False)
-        index_columns = kw.pop("index_columns", False)
+        for arg in ("group_columns", "index_columns", "taql_where"):
+            if kw.pop(arg, False):
+                raise ValueError(f'"{arg}" is not supported for zarr inputs')
 
-        if group_columns:
-            raise ValueError('"group_columns" is not supported ' "for zarr inputs")
-        if index_columns:
-            raise ValueError('"index_columns" is not supported ' "for zarr inputs")
         try:
             from daskms.experimental.zarr import xds_from_zarr
 
@@ -250,13 +251,9 @@ class ParquetFormat(BaseTableFormat):
         return self._subtables
 
     def reader(self, **kw):
-        group_columns = kw.pop("group_columns", False)
-        index_columns = kw.pop("index_columns", False)
-
-        if group_columns:
-            raise ValueError('"group_column" is not supported ' "for parquet inputs")
-        if index_columns:
-            raise ValueError('"index_columns" is not supported ' "for parquet inputs")
+        for arg in ("group_columns", "index_columns", "taql_where"):
+            if kw.pop(arg, False):
+                raise ValueError(f'"{arg}" is not supported for parquet inputs')
 
         try:
             from daskms.experimental.arrow.reads import xds_from_parquet
@@ -372,6 +369,14 @@ class Convert(Application):
             "from casa format.",
         )
         parser.add_argument(
+            "--taql-where",
+            default="",
+            help="TAQL where clause. "
+            "Only useable with CASA inputs. "
+            "For example, to exclude auto-correlations "
+            '"ANTENNA1 != ANTENNA2"',
+        )
+        parser.add_argument(
             "-f",
             "--format",
             choices=["ms", "casa", "zarr", "parquet"],
@@ -438,7 +443,9 @@ class Convert(Application):
         out_fmt = TableFormat.from_type(args.format)
 
         reader = in_fmt.reader(
-            group_columns=args.group_columns, index_columns=args.index_columns
+            group_columns=args.group_columns,
+            index_columns=args.index_columns,
+            taql_where=args.taql_where,
         )
         writer = out_fmt.writer()
 


### PR DESCRIPTION
- Closes #263 

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
