### PR TITLE
Support reading CASA Keywords at both Table => Dataset and Column => Variable level

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+X.Y.Z (YYYY-MM-DD)
+------------------
+* Support reading CASA Keywords at both Table => Dataset and Column => Variable level (:pr:`265`)
+
 0.2.15 (2022-10-19)
 -------------------
 * Fix poetry install and cache hit detection on CI (:pr:`266`)

--- a/daskms/casa_schema.py
+++ b/daskms/casa_schema.py
@@ -1,0 +1,127 @@
+import itertools
+import logging
+from pprint import pformat
+
+from daskms.constants import CASA_KEYWORDS, DASKMS_METADATA
+from daskms.columns import infer_casa_type
+from daskms.dataset_schema import DatasetSchema, ColumnSchema, unify_schemas
+from daskms.utils import Frozen
+
+log = logging.getLogger(__name__)
+
+
+class CasaUnificationError(ValueError):
+    pass
+
+
+class CasaSchema(DatasetSchema):
+    @classmethod
+    def unify_attrs(cls, attrs):
+        if len(attrs) == 0:
+            return {}
+
+        metadata = set(map(Frozen, (a.get(DASKMS_METADATA, {}) for a in attrs)))
+
+        if len(metadata) != 1:
+            raise CasaUnificationError(f"{pformat(metadata)} are not consistent")
+
+        return {DASKMS_METADATA: metadata.pop()}
+
+    @classmethod
+    def unify_column(cls, column, schema):
+        it = zip(schema.dims, schema.shape, schema.attrs)
+        new_dims = []
+        new_shape = []
+        new_attrs = []
+
+        for _, (dims, shape, attrs) in enumerate(it):
+            if len(dims) == 0:
+                log.warning(
+                    f"Ignoring column {column} with " f"zero-length dims {schema.dims}"
+                )
+                continue
+
+            if dims[0] != "row":
+                log.warning(
+                    f"Ignoring column {column} without "
+                    f"'row' as the starting dimension {schema.dims}"
+                )
+                continue
+
+            new_dims.append(dims[1:])
+            new_shape.append(shape[1:])
+            new_attrs.append(Frozen(attrs))
+
+        typ = set(schema.type)
+        dtype = set(schema.dtype)
+        dims = set(new_dims)
+        shape = set(new_shape)
+        attrs = set(new_attrs)
+
+        if len(typ) != 1:
+            raise CasaUnificationError(f"Inconsistent column types {typ}")
+
+        if len(dtype) != 1:
+            raise CasaUnificationError(f"Inconsistent column dtypes {dtype}")
+
+        if len(dims) != 1:
+            raise CasaUnificationError(f"Inconsistent column dims {dims}")
+
+        if len(attrs) != 1:
+            raise CasaUnificationError(f"Inconsistent column attributes {attrs}")
+
+        chunks = None
+
+        return ColumnSchema(
+            typ.pop(), dims.pop(), dtype.pop(), chunks, shape, attrs.pop().value
+        )
+
+    @classmethod
+    def from_datasets(cls, datasets):
+        if not isinstance(datasets, (tuple, list)):
+            datasets = [datasets]
+
+        schemas = list(map(DatasetSchema.from_dataset, datasets))
+        unified_schema = unify_schemas(schemas)
+
+        data_vars = {
+            c: cls.unify_column(c, s) for c, s in unified_schema.data_vars.items()
+        }
+        coords = {c: cls.unify_column(c, s) for c, s in unified_schema.coords.items()}
+        attrs = cls.unify_attrs(unified_schema.attrs)
+
+        return CasaSchema(data_vars, coords, attrs)
+
+    def to_casa_schema(self):
+        desc = {}
+
+        variables = itertools.chain(self.data_vars.items(), self.coords.items())
+        variables = filter(lambda x: x[0] != "ROWID", variables)
+
+        for column, var in variables:
+            casa_type = infer_casa_type(var.dtype)
+            keywords = var.attrs.get(DASKMS_METADATA, {}).get(CASA_KEYWORDS, {})
+
+            column_desc = {
+                "_c_order": True,
+                "comment": f"{column} column",
+                "dataManagerGroup": "StandardStMan",
+                "dataManagerType": "StandardStMan",
+                "keywords": keywords,
+                "maxlen": 0,
+                "option": 0,
+                "valueType": casa_type,
+            }
+
+            if var.ndim > 0:
+                column_desc["ndim"] = var.ndim
+
+            if len(var.shape) == 1:
+                col_shape = var.shape.pop()
+
+                if len(col_shape) > 0:
+                    column_desc["shape"] = col_shape
+
+            desc[column] = column_desc
+
+        return desc

--- a/daskms/columns.py
+++ b/daskms/columns.py
@@ -97,7 +97,9 @@ class ColumnMetadataError(Exception):
     pass
 
 
-ColumnMetadata = namedtuple("ColumnMetadata", ["shape", "dims", "chunks", "dtype"])
+ColumnMetadata = namedtuple(
+    "ColumnMetadata", ["shape", "dims", "chunks", "dtype", "keywords"]
+)
 
 
 def column_metadata(column, table_proxy, table_schema, chunks, exemplar_row=0):
@@ -122,16 +124,8 @@ def column_metadata(column, table_proxy, table_schema, chunks, exemplar_row=0):
 
     Returns
     -------
-    shape : tuple
-        Shape of column (excluding the row dimension).
-        For example :code:`(16, 4)`
-    dims : tuple
-        Dask dimension schema. For example :code:`("chan", "corr")`
-    dim_chunks : list of tuples
-        Dimension chunks. For example :code:`[chan_chunks, corr_chunks]`.
-    dtype : :class:`numpy.dtype`
-        Column data type (numpy)
-
+    column_metadata : ColumnMetadata
+        namedtuple containing Column Metadata
 
     Raises
     ------
@@ -243,7 +237,8 @@ def column_metadata(column, table_proxy, table_schema, chunks, exemplar_row=0):
             "dim_chunks '%s' do not agree." % (shape, dims, dim_chunks)
         )
 
-    return ColumnMetadata(shape, dims, dim_chunks, dtype)
+    keywords = coldesc.get("keywords", None)
+    return ColumnMetadata(shape, dims, dim_chunks, dtype, keywords)
 
 
 def dim_extents_array(dim, chunks):

--- a/daskms/conftest.py
+++ b/daskms/conftest.py
@@ -353,3 +353,10 @@ def py_minio_client(minio_client, minio_admin, minio_alias, minio_user_key):
         secret_key=minio_user_key,
         secure=MINIO_URL.scheme == "https",
     )
+
+
+@pytest.fixture
+def example_ms():
+    from daskms.example_data import example_ms as ms_factory
+
+    yield ms_factory()

--- a/daskms/constants.py
+++ b/daskms/constants.py
@@ -1,4 +1,4 @@
 DASKMS_PARTITION_KEY = "__daskms_partition_schema__"
 DASKMS_METADATA = "__daskms_metadata__"
-CASA_METADATA = "__casa_metadata__"
+CASA_KEYWORDS = "__casa_keywords__"
 DASKMS_PARQUET_VERSION = "0.0.1"

--- a/daskms/constants.py
+++ b/daskms/constants.py
@@ -1,3 +1,4 @@
 DASKMS_PARTITION_KEY = "__daskms_partition_schema__"
 DASKMS_METADATA = "__daskms_metadata__"
+CASA_METADATA = "__casa_metadata__"
 DASKMS_PARQUET_VERSION = "0.0.1"

--- a/daskms/constants.py
+++ b/daskms/constants.py
@@ -1,4 +1,5 @@
 DASKMS_PARTITION_KEY = "__daskms_partition_schema__"
+ARROW_METADATA = "__daskms_arrow_metadata__"
 DASKMS_METADATA = "__daskms_metadata__"
 CASA_KEYWORDS = "__casa_keywords__"
 DASKMS_PARQUET_VERSION = "0.0.1"

--- a/daskms/dataset_schema.py
+++ b/daskms/dataset_schema.py
@@ -52,7 +52,7 @@ def encode_attr(arg):
 
 def decode_attr(arg):
     if isinstance(arg, (tuple, list)):
-        return type(arg)(map(decode_attr, arg))
+        return tuple(map(decode_attr, arg))
     elif isinstance(arg, set):
         return set(map(decode_attr, arg))
     elif isinstance(arg, dict):

--- a/daskms/experimental/arrow/arrow_schema.py
+++ b/daskms/experimental/arrow/arrow_schema.py
@@ -87,7 +87,7 @@ class ArrowSchema(DatasetSchema):
 
         for i, a in enumerate(attrs):
             try:
-                partition_key = a[DASKMS_PARTITION_KEY]
+                metadata = a.get(DASKMS_METADATA, {})[DASKMS_PARTITION_KEY]
             except KeyError:
                 attrs[i] = ()
             else:

--- a/daskms/experimental/arrow/tests/test_parquet.py
+++ b/daskms/experimental/arrow/tests/test_parquet.py
@@ -15,7 +15,7 @@ from daskms.experimental.arrow.extension_types import TensorArray
 from daskms.experimental.arrow.reads import xds_from_parquet
 from daskms.experimental.arrow.reads import partition_chunking
 from daskms.experimental.arrow.writes import xds_to_parquet
-from daskms.constants import DASKMS_PARTITION_KEY
+from daskms.constants import DASKMS_METADATA, DASKMS_PARTITION_KEY
 
 pa = pytest.importorskip("pyarrow")
 pq = pytest.importorskip("pyarrow.parquet")
@@ -146,8 +146,10 @@ def parquet_tester(ms, store):
             assert_array_equal(var.data, pq_var.data)
             assert var.dims == pq_var.dims
 
-        partitions = ds.attrs[DASKMS_PARTITION_KEY]
-        pq_partitions = pq_ds.attrs[DASKMS_PARTITION_KEY]
+        partitions = ds.attrs.get(DASKMS_METADATA, {}).get(DASKMS_PARTITION_KEY, ())
+        pq_partitions = pq_ds.attrs.get(DASKMS_METADATA, {}).get(
+            DASKMS_PARTITION_KEY, ()
+        )
         assert partitions == pq_partitions
 
         for field, dtype in partitions:

--- a/daskms/experimental/arrow/writes.py
+++ b/daskms/experimental/arrow/writes.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import itertools
 from pathlib import Path
 from threading import Lock
@@ -8,7 +9,7 @@ import numpy as np
 
 from daskms.dataset import Dataset
 from daskms.optimisation import inlined_array
-from daskms.constants import DASKMS_PARTITION_KEY
+from daskms.constants import DASKMS_PARTITION_KEY, DASKMS_METADATA
 from daskms.fsspec_store import DaskMSStore
 from daskms.experimental.arrow.arrow_schema import ArrowSchema
 from daskms.experimental.arrow.extension_types import TensorArray
@@ -32,17 +33,17 @@ else:
 
 class ParquetFragment:
     def __init__(self, store, key, schema, dataset_id):
-        partition = schema.attrs.get(DASKMS_PARTITION_KEY, False)
+        partition = schema.attrs.get(DASKMS_METADATA, {}).get(
+            DASKMS_PARTITION_KEY, False
+        )
 
         if not partition:
             # There's no specific partitioning schema,
             # make one up
+            attrs = deepcopy(schema.attrs)
+            attrs[DASKMS_METADATA][DASKMS_PARTITION_KEY] = (("DATASET", "int32"),)
+            schema = ArrowSchema(schema.data_vars, schema.coords, attrs)
             partition = (("DATASET", dataset_id),)
-            schema = ArrowSchema(
-                schema.data_vars,
-                schema.coords,
-                {**schema.attrs, DASKMS_PARTITION_KEY: (("DATASET", "int32"),)},
-            )
         else:
             partition = tuple((p, schema.attrs[p]) for p, _ in partition)
 
@@ -60,7 +61,6 @@ class ParquetFragment:
         return (ParquetFragment, (self.store, self.key, self.schema, self.dataset_id))
 
     def write(self, chunk, *data):
-
         table_path = (
             self.key if self.store.table else self.store.join(["MAIN", self.key])
         )
@@ -164,15 +164,14 @@ def xds_to_parquet(xds, store, columns=None, **kwargs):
         writes = inlined_array(writes, chunk_ids)
 
         # Transfer any partition information over to the write dataset
-        partition = ds.attrs.get(DASKMS_PARTITION_KEY, False)
+        metadata = ds.attrs.get(DASKMS_METADATA, {})
+        partition = metadata.get(DASKMS_PARTITION_KEY, False)
 
         if not partition:
-            attrs = None
+            attrs = ds.attrs
         else:
-            attrs = {
-                DASKMS_PARTITION_KEY: partition,
-                **{k: getattr(ds, k) for k, _ in partition},
-            }
+            attrs = ds.attrs.copy()
+            attrs.update((k, getattr(ds, k)) for k, _ in partition)
 
         datasets.append(Dataset({"WRITE": (("row",), writes)}, attrs=attrs))
 

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -9,7 +9,7 @@ from dask.base import tokenize
 import numpy as np
 import warnings
 
-from daskms.constants import DASKMS_PARTITION_KEY
+from daskms.constants import DASKMS_PARTITION_KEY, DASKMS_METADATA
 from daskms.dataset import Dataset, Variable
 from daskms.dataset_schema import DatasetSchema, encode_type, decode_type, decode_attr
 from daskms.experimental.utils import (
@@ -322,15 +322,14 @@ def xds_to_zarr(xds, store, columns=None, rechunk=False, consolidated=True, **kw
         )
 
         # Transfer any partition information over to the write dataset
-        partition = ds.attrs.get(DASKMS_PARTITION_KEY, False)
+        metadata = ds.attrs.get(DASKMS_METADATA, {})
+        partition = metadata.get(DASKMS_PARTITION_KEY, False)
 
         if not partition:
-            attrs = None
+            attrs = ds.attrs
         else:
-            attrs = {
-                DASKMS_PARTITION_KEY: partition,
-                **{k: getattr(ds, k) for k, _ in partition},
-            }
+            attrs = ds.attrs.copy()
+            attrs.update((k, getattr(ds, k)) for k, _ in partition)
 
         write_datasets.append(Dataset(data_vars, attrs=attrs))
 

--- a/daskms/experimental/zarr/tests/test_zarr.py
+++ b/daskms/experimental/zarr/tests/test_zarr.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_array_equal
 import pytest
 
 from daskms import xds_from_ms, xds_from_table, xds_from_storage_ms
-from daskms.constants import DASKMS_PARTITION_KEY
+from daskms.constants import DASKMS_PARTITION_KEY, DASKMS_METADATA
 from daskms.dataset import Dataset
 from daskms.experimental.zarr import xds_from_zarr, xds_to_zarr
 from daskms.fsspec_store import DaskMSStore, UnknownStoreTypeError
@@ -135,7 +135,7 @@ def zarr_tester(ms, spw_table, ant_table, zarr_store, spw_store, ant_store):
     assert len(ms_datasets) == len(main_zarr_writes)
 
     for ms_ds, zw_ds in zip(ms_datasets, main_zarr_writes):
-        for k, _ in ms_ds.attrs[DASKMS_PARTITION_KEY]:
+        for k, _ in ms_ds.attrs[DASKMS_METADATA][DASKMS_PARTITION_KEY]:
             assert getattr(ms_ds, k) == getattr(zw_ds, k)
 
     writes = [main_zarr_writes]

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -268,7 +268,7 @@ def _dataset_variable_factory(
         )
 
         dask_array = inlined_array(dask_array)
-        array_attrs = {DASKMS_METADATA: {CASA_KEYWORDS: {"keywords": meta.keywords}}}
+        array_attrs = {DASKMS_METADATA: {CASA_KEYWORDS: meta.keywords}}
 
         # Assign into variable and dimension dataset
         dataset_vars[column] = (full_dims, dask_array, array_attrs)
@@ -346,8 +346,10 @@ class DatasetFactory(object):
             coords = {"ROWID": rowid}
 
         attrs = {
-            DASKMS_PARTITION_KEY: (),
-            DASKMS_METADATA: {CASA_KEYWORDS: table_proxy.getkeywords().result()},
+            DASKMS_METADATA: {
+                CASA_KEYWORDS: table_proxy.getkeywords().result(),
+                DASKMS_PARTITION_KEY: (),
+            }
         }
 
         return Dataset(variables, coords=coords, attrs=attrs)
@@ -405,8 +407,10 @@ class DatasetFactory(object):
                 (c, g.dtype.name) for c, g in zip(self.group_cols, group_id)
             )
             attrs = {
-                DASKMS_PARTITION_KEY: partitions,
-                DASKMS_METADATA: {CASA_KEYWORDS: table_proxy.getkeywords().result()},
+                DASKMS_METADATA: {
+                    CASA_KEYWORDS: table_proxy.getkeywords().result(),
+                    DASKMS_PARTITION_KEY: partitions,
+                }
             }
 
             # Use python types which are json serializable

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -345,7 +345,10 @@ class DatasetFactory(object):
         else:
             coords = {"ROWID": rowid}
 
-        attrs = {DASKMS_PARTITION_KEY: ()}
+        attrs = {
+            DASKMS_PARTITION_KEY: (),
+            DASKMS_METADATA: {CASA_KEYWORDS: table_proxy.getkeywords().result()},
+        }
 
         return Dataset(variables, coords=coords, attrs=attrs)
 
@@ -401,7 +404,10 @@ class DatasetFactory(object):
             partitions = tuple(
                 (c, g.dtype.name) for c, g in zip(self.group_cols, group_id)
             )
-            attrs = {DASKMS_PARTITION_KEY: partitions}
+            attrs = {
+                DASKMS_PARTITION_KEY: partitions,
+                DASKMS_METADATA: {CASA_KEYWORDS: table_proxy.getkeywords().result()},
+            }
 
             # Use python types which are json serializable
             group_id = [gid.item() for gid in group_id]

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -14,7 +14,7 @@ from daskms.columns import (
     dim_extents_array,
     infer_dtype,
 )
-from daskms.constants import DASKMS_PARTITION_KEY
+from daskms.constants import DASKMS_METADATA, DASKMS_PARTITION_KEY, CASA_METADATA
 from daskms.ordering import (
     ordering_taql,
     row_ordering,
@@ -268,9 +268,10 @@ def _dataset_variable_factory(
         )
 
         dask_array = inlined_array(dask_array)
+        array_attrs = {DASKMS_METADATA: {CASA_METADATA: {"keywords": meta.keywords}}}
 
         # Assign into variable and dimension dataset
-        dataset_vars[column] = (full_dims, dask_array)
+        dataset_vars[column] = (full_dims, dask_array, array_attrs)
 
     return dataset_vars
 

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -14,7 +14,7 @@ from daskms.columns import (
     dim_extents_array,
     infer_dtype,
 )
-from daskms.constants import DASKMS_METADATA, DASKMS_PARTITION_KEY, CASA_METADATA
+from daskms.constants import DASKMS_METADATA, DASKMS_PARTITION_KEY, CASA_KEYWORDS
 from daskms.ordering import (
     ordering_taql,
     row_ordering,
@@ -268,7 +268,7 @@ def _dataset_variable_factory(
         )
 
         dask_array = inlined_array(dask_array)
-        array_attrs = {DASKMS_METADATA: {CASA_METADATA: {"keywords": meta.keywords}}}
+        array_attrs = {DASKMS_METADATA: {CASA_KEYWORDS: {"keywords": meta.keywords}}}
 
         # Assign into variable and dimension dataset
         dataset_vars[column] = (full_dims, dask_array, array_attrs)

--- a/daskms/tests/test_casa_schema.py
+++ b/daskms/tests/test_casa_schema.py
@@ -1,0 +1,383 @@
+from daskms import xds_from_ms, xds_from_table
+from daskms.casa_schema import CasaSchema
+
+import numpy as np
+
+
+def test_casa_unified_schema_main(example_ms):
+    datasets = xds_from_ms(example_ms)
+    assert len(datasets) == 2
+
+    schema = CasaSchema.from_datasets(datasets)
+
+    for ds in datasets:
+        for column, var in ds.data_vars.items():
+            s = schema.data_vars[column]
+            assert s.dims == var.dims[1:]
+            # assert s.shape == {v.shape[1:] for c, v in ds.data_vars.items() if c == column}
+            assert np.dtype(s.dtype) == var.dtype
+            assert isinstance(var.data, s.type)
+            assert s.attrs == var.attrs
+
+    assert schema.to_casa_schema() == {
+        "ANTENNA1": {
+            "_c_order": True,
+            "comment": "ANTENNA1 column",
+            "dataManagerGroup": "StandardStMan",
+            "dataManagerType": "StandardStMan",
+            "keywords": {},
+            "maxlen": 0,
+            "option": 0,
+            "valueType": "INTEGER",
+        },
+        "ANTENNA2": {
+            "_c_order": True,
+            "comment": "ANTENNA2 column",
+            "dataManagerGroup": "StandardStMan",
+            "dataManagerType": "StandardStMan",
+            "keywords": {},
+            "maxlen": 0,
+            "option": 0,
+            "valueType": "INTEGER",
+        },
+        "ARRAY_ID": {
+            "_c_order": True,
+            "comment": "ARRAY_ID column",
+            "dataManagerGroup": "StandardStMan",
+            "dataManagerType": "StandardStMan",
+            "keywords": {},
+            "maxlen": 0,
+            "option": 0,
+            "valueType": "INTEGER",
+        },
+        "DATA": {
+            "_c_order": True,
+            "comment": "DATA column",
+            "dataManagerGroup": "StandardStMan",
+            "dataManagerType": "StandardStMan",
+            "keywords": {},
+            "maxlen": 0,
+            "option": 0,
+            "ndim": 2,
+            "valueType": "COMPLEX",
+        },
+        "EXPOSURE": {
+            "_c_order": True,
+            "comment": "EXPOSURE column",
+            "dataManagerGroup": "StandardStMan",
+            "dataManagerType": "StandardStMan",
+            "keywords": {"QuantumUnits": ["s"]},
+            "maxlen": 0,
+            "option": 0,
+            "valueType": "DOUBLE",
+        },
+        "FEED1": {
+            "_c_order": True,
+            "comment": "FEED1 column",
+            "dataManagerGroup": "StandardStMan",
+            "dataManagerType": "StandardStMan",
+            "keywords": {},
+            "maxlen": 0,
+            "option": 0,
+            "valueType": "INTEGER",
+        },
+        "FEED2": {
+            "_c_order": True,
+            "comment": "FEED2 column",
+            "dataManagerGroup": "StandardStMan",
+            "dataManagerType": "StandardStMan",
+            "keywords": {},
+            "maxlen": 0,
+            "option": 0,
+            "valueType": "INTEGER",
+        },
+        "FLAG_ROW": {
+            "_c_order": True,
+            "comment": "FLAG_ROW column",
+            "dataManagerGroup": "StandardStMan",
+            "dataManagerType": "StandardStMan",
+            "keywords": {},
+            "maxlen": 0,
+            "option": 0,
+            "valueType": "BOOLEAN",
+        },
+        "INTERVAL": {
+            "_c_order": True,
+            "comment": "INTERVAL column",
+            "dataManagerGroup": "StandardStMan",
+            "dataManagerType": "StandardStMan",
+            "keywords": {"QuantumUnits": ["s"]},
+            "maxlen": 0,
+            "option": 0,
+            "valueType": "DOUBLE",
+        },
+        "OBSERVATION_ID": {
+            "_c_order": True,
+            "comment": "OBSERVATION_ID column",
+            "dataManagerGroup": "StandardStMan",
+            "dataManagerType": "StandardStMan",
+            "keywords": {},
+            "maxlen": 0,
+            "option": 0,
+            "valueType": "INTEGER",
+        },
+        "PROCESSOR_ID": {
+            "_c_order": True,
+            "comment": "PROCESSOR_ID column",
+            "dataManagerGroup": "StandardStMan",
+            "dataManagerType": "StandardStMan",
+            "keywords": {},
+            "maxlen": 0,
+            "option": 0,
+            "valueType": "INTEGER",
+        },
+        "SCAN_NUMBER": {
+            "_c_order": True,
+            "comment": "SCAN_NUMBER column",
+            "dataManagerGroup": "StandardStMan",
+            "dataManagerType": "StandardStMan",
+            "keywords": {},
+            "maxlen": 0,
+            "option": 0,
+            "valueType": "INTEGER",
+        },
+        "STATE_ID": {
+            "_c_order": True,
+            "comment": "STATE_ID column",
+            "dataManagerGroup": "StandardStMan",
+            "dataManagerType": "StandardStMan",
+            "keywords": {},
+            "maxlen": 0,
+            "option": 0,
+            "valueType": "INTEGER",
+        },
+        "TIME": {
+            "_c_order": True,
+            "comment": "TIME column",
+            "dataManagerGroup": "StandardStMan",
+            "dataManagerType": "StandardStMan",
+            "keywords": {
+                "MEASINFO": {"Ref": "UTC", "type": "epoch"},
+                "QuantumUnits": ["s"],
+            },
+            "maxlen": 0,
+            "option": 0,
+            "valueType": "DOUBLE",
+        },
+        "TIME_CENTROID": {
+            "_c_order": True,
+            "comment": "TIME_CENTROID column",
+            "dataManagerGroup": "StandardStMan",
+            "dataManagerType": "StandardStMan",
+            "keywords": {
+                "MEASINFO": {"Ref": "UTC", "type": "epoch"},
+                "QuantumUnits": ["s"],
+            },
+            "maxlen": 0,
+            "option": 0,
+            "valueType": "DOUBLE",
+        },
+        "UVW": {
+            "_c_order": True,
+            "comment": "UVW column",
+            "dataManagerGroup": "StandardStMan",
+            "dataManagerType": "StandardStMan",
+            "keywords": {
+                "MEASINFO": {"Ref": "ITRF", "type": "uvw"},
+                "QuantumUnits": ["m", "m", "m"],
+            },
+            "maxlen": 0,
+            "ndim": 1,
+            "option": 0,
+            "shape": (3,),
+            "valueType": "DOUBLE",
+        },
+    }
+
+
+def test_casa_unified_schema_spw(example_ms):
+    datasets = xds_from_table(f"{example_ms}::SPECTRAL_WINDOW")
+    assert len(datasets) == 1
+
+    schema = CasaSchema.from_datasets(datasets)
+
+    for ds in datasets:
+        for column, var in ds.data_vars.items():
+            s = schema.data_vars[column]
+            assert s.dims == var.dims[1:]
+            assert s.shape == {var.shape[1:]}
+            assert np.dtype(s.dtype) == var.dtype
+            assert isinstance(var.data, s.type)
+            assert s.attrs == var.attrs
+
+    np.testing.assert_equal(
+        schema.to_casa_schema(),
+        {
+            "CHAN_FREQ": {
+                "_c_order": True,
+                "comment": "CHAN_FREQ column",
+                "dataManagerGroup": "StandardStMan",
+                "dataManagerType": "StandardStMan",
+                "keywords": {
+                    "MEASINFO": {
+                        "TabRefCodes": np.array(
+                            [0, 1, 2, 3, 4, 5, 6, 7, 8, 64], dtype=np.uint32
+                        ),
+                        "TabRefTypes": [
+                            "REST",
+                            "LSRK",
+                            "LSRD",
+                            "BARY",
+                            "GEO",
+                            "TOPO",
+                            "GALACTO",
+                            "LGROUP",
+                            "CMB",
+                            "Undefined",
+                        ],
+                        "VarRefCol": "MEAS_FREQ_REF",
+                        "type": "frequency",
+                    },
+                    "QuantumUnits": ["Hz"],
+                },
+                "maxlen": 0,
+                "ndim": 1,
+                "option": 0,
+                "shape": (16,),
+                "valueType": "DOUBLE",
+            },
+            "CHAN_WIDTH": {
+                "_c_order": True,
+                "comment": "CHAN_WIDTH column",
+                "dataManagerGroup": "StandardStMan",
+                "dataManagerType": "StandardStMan",
+                "keywords": {"QuantumUnits": ["Hz"]},
+                "maxlen": 0,
+                "ndim": 1,
+                "option": 0,
+                "shape": (16,),
+                "valueType": "DOUBLE",
+            },
+            "FLAG_ROW": {
+                "_c_order": True,
+                "comment": "FLAG_ROW column",
+                "dataManagerGroup": "StandardStMan",
+                "dataManagerType": "StandardStMan",
+                "keywords": {},
+                "maxlen": 0,
+                "option": 0,
+                "valueType": "BOOLEAN",
+            },
+            "FREQ_GROUP": {
+                "_c_order": True,
+                "comment": "FREQ_GROUP column",
+                "dataManagerGroup": "StandardStMan",
+                "dataManagerType": "StandardStMan",
+                "keywords": {},
+                "maxlen": 0,
+                "option": 0,
+                "valueType": "INTEGER",
+            },
+            "FREQ_GROUP_NAME": {
+                "_c_order": True,
+                "comment": "FREQ_GROUP_NAME column",
+                "dataManagerGroup": "StandardStMan",
+                "dataManagerType": "StandardStMan",
+                "keywords": {},
+                "maxlen": 0,
+                "option": 0,
+                "valueType": "STRING",
+            },
+            "IF_CONV_CHAIN": {
+                "_c_order": True,
+                "comment": "IF_CONV_CHAIN column",
+                "dataManagerGroup": "StandardStMan",
+                "dataManagerType": "StandardStMan",
+                "keywords": {},
+                "maxlen": 0,
+                "option": 0,
+                "valueType": "INTEGER",
+            },
+            "MEAS_FREQ_REF": {
+                "_c_order": True,
+                "comment": "MEAS_FREQ_REF column",
+                "dataManagerGroup": "StandardStMan",
+                "dataManagerType": "StandardStMan",
+                "keywords": {},
+                "maxlen": 0,
+                "option": 0,
+                "valueType": "INTEGER",
+            },
+            "NAME": {
+                "_c_order": True,
+                "comment": "NAME column",
+                "dataManagerGroup": "StandardStMan",
+                "dataManagerType": "StandardStMan",
+                "keywords": {},
+                "maxlen": 0,
+                "option": 0,
+                "valueType": "STRING",
+            },
+            "NET_SIDEBAND": {
+                "_c_order": True,
+                "comment": "NET_SIDEBAND column",
+                "dataManagerGroup": "StandardStMan",
+                "dataManagerType": "StandardStMan",
+                "keywords": {},
+                "maxlen": 0,
+                "option": 0,
+                "valueType": "INTEGER",
+            },
+            "NUM_CHAN": {
+                "_c_order": True,
+                "comment": "NUM_CHAN column",
+                "dataManagerGroup": "StandardStMan",
+                "dataManagerType": "StandardStMan",
+                "keywords": {},
+                "maxlen": 0,
+                "option": 0,
+                "valueType": "INTEGER",
+            },
+            "REF_FREQUENCY": {
+                "_c_order": True,
+                "comment": "REF_FREQUENCY column",
+                "dataManagerGroup": "StandardStMan",
+                "dataManagerType": "StandardStMan",
+                "keywords": {
+                    "MEASINFO": {
+                        "TabRefCodes": np.array(
+                            [0, 1, 2, 3, 4, 5, 6, 7, 8, 64], dtype=np.uint32
+                        ),
+                        "TabRefTypes": [
+                            "REST",
+                            "LSRK",
+                            "LSRD",
+                            "BARY",
+                            "GEO",
+                            "TOPO",
+                            "GALACTO",
+                            "LGROUP",
+                            "CMB",
+                            "Undefined",
+                        ],
+                        "VarRefCol": "MEAS_FREQ_REF",
+                        "type": "frequency",
+                    },
+                    "QuantumUnits": ["Hz"],
+                },
+                "maxlen": 0,
+                "option": 0,
+                "valueType": "DOUBLE",
+            },
+            "TOTAL_BANDWIDTH": {
+                "_c_order": True,
+                "comment": "TOTAL_BANDWIDTH column",
+                "dataManagerGroup": "StandardStMan",
+                "dataManagerType": "StandardStMan",
+                "keywords": {"QuantumUnits": ["Hz"]},
+                "maxlen": 0,
+                "option": 0,
+                "valueType": "DOUBLE",
+            },
+        },
+    )

--- a/daskms/tests/test_dataset_keywords.py
+++ b/daskms/tests/test_dataset_keywords.py
@@ -120,35 +120,31 @@ def test_write_table_proxy_keyword(ms):
 
 def test_dataset_and_column_keywords(keyword_ms):
     spw_ds = xds_from_table(f"{keyword_ms}::SPECTRAL_WINDOW")
-
-    np.testing.assert_equal(
-        spw_ds[0].REF_FREQUENCY.attrs,
-        {
-            "__daskms_metadata__": {
-                "__casa_keywords__": {
-                    "keywords": {
-                        "QuantumUnits": ["Hz"],
-                        "MEASINFO": {
-                            "type": "frequency",
-                            "VarRefCol": "MEAS_FREQ_REF",
-                            "TabRefTypes": [
-                                "REST",
-                                "LSRK",
-                                "LSRD",
-                                "BARY",
-                                "GEO",
-                                "TOPO",
-                                "GALACTO",
-                                "LGROUP",
-                                "CMB",
-                                "Undefined",
-                            ],
-                            "TabRefCodes": np.array(
-                                [0, 1, 2, 3, 4, 5, 6, 7, 8, 64], dtype=np.uint32
-                            ),
-                        },
-                    }
-                }
+    expected = {
+        "__daskms_metadata__": {
+            "__casa_keywords__": {
+                "QuantumUnits": ["Hz"],
+                "MEASINFO": {
+                    "type": "frequency",
+                    "VarRefCol": "MEAS_FREQ_REF",
+                    "TabRefTypes": [
+                        "REST",
+                        "LSRK",
+                        "LSRD",
+                        "BARY",
+                        "GEO",
+                        "TOPO",
+                        "GALACTO",
+                        "LGROUP",
+                        "CMB",
+                        "Undefined",
+                    ],
+                    "TabRefCodes": np.array(
+                        [0, 1, 2, 3, 4, 5, 6, 7, 8, 64], dtype=np.uint32
+                    ),
+                },
             }
-        },
-    )
+        }
+    }
+
+    np.testing.assert_equal(spw_ds[0].REF_FREQUENCY.attrs, expected)

--- a/daskms/tests/test_dataset_keywords.py
+++ b/daskms/tests/test_dataset_keywords.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
 import dask
+import numpy as np
 import pyrap.tables as pt
 import pytest
 
 from daskms.example_data import example_ms
 from daskms.table_proxy import TableProxy
-from daskms import xds_to_table, xds_from_ms
+from daskms import xds_to_table, xds_from_ms, xds_from_table
 from daskms.dataset import Dataset
 
 
@@ -115,3 +116,36 @@ def test_write_table_proxy_keyword(ms):
     writes = xds_to_table(datasets, ms, [], table_proxy=False)
     assert isinstance(writes, list)
     assert all(isinstance(w, Dataset) for w in writes)
+
+
+def test_dataset_and_column_keywords(keyword_ms):
+    spw_ds = xds_from_table(f"{keyword_ms}::SPECTRAL_WINDOW")
+
+    assert spw_ds[0].REF_FREQUENCY.attrs == {
+        "__daskms_metadata__": {
+            "__casa_keywords__": {
+                "keywords": {
+                    "QuantumUnits": ["Hz"],
+                    "MEASINFO": {
+                        "type": "frequency",
+                        "VarRefCol": "MEAS_FREQ_REF",
+                        "TabRefTypes": [
+                            "REST",
+                            "LSRK",
+                            "LSRD",
+                            "BARY",
+                            "GEO",
+                            "TOPO",
+                            "GALACTO",
+                            "LGROUP",
+                            "CMB",
+                            "Undefined",
+                        ],
+                        "TabRefCodes": np.array(
+                            [0, 1, 2, 3, 4, 5, 6, 7, 8, 64], dtype=np.uint32
+                        ),
+                    },
+                }
+            }
+        }
+    }

--- a/daskms/tests/test_dataset_keywords.py
+++ b/daskms/tests/test_dataset_keywords.py
@@ -121,31 +121,34 @@ def test_write_table_proxy_keyword(ms):
 def test_dataset_and_column_keywords(keyword_ms):
     spw_ds = xds_from_table(f"{keyword_ms}::SPECTRAL_WINDOW")
 
-    assert spw_ds[0].REF_FREQUENCY.attrs == {
-        "__daskms_metadata__": {
-            "__casa_keywords__": {
-                "keywords": {
-                    "QuantumUnits": ["Hz"],
-                    "MEASINFO": {
-                        "type": "frequency",
-                        "VarRefCol": "MEAS_FREQ_REF",
-                        "TabRefTypes": [
-                            "REST",
-                            "LSRK",
-                            "LSRD",
-                            "BARY",
-                            "GEO",
-                            "TOPO",
-                            "GALACTO",
-                            "LGROUP",
-                            "CMB",
-                            "Undefined",
-                        ],
-                        "TabRefCodes": np.array(
-                            [0, 1, 2, 3, 4, 5, 6, 7, 8, 64], dtype=np.uint32
-                        ),
-                    },
+    np.testing.assert_equal(
+        spw_ds[0].REF_FREQUENCY.attrs,
+        {
+            "__daskms_metadata__": {
+                "__casa_keywords__": {
+                    "keywords": {
+                        "QuantumUnits": ["Hz"],
+                        "MEASINFO": {
+                            "type": "frequency",
+                            "VarRefCol": "MEAS_FREQ_REF",
+                            "TabRefTypes": [
+                                "REST",
+                                "LSRK",
+                                "LSRD",
+                                "BARY",
+                                "GEO",
+                                "TOPO",
+                                "GALACTO",
+                                "LGROUP",
+                                "CMB",
+                                "Undefined",
+                            ],
+                            "TabRefCodes": np.array(
+                                [0, 1, 2, 3, 4, 5, 6, 7, 8, 64], dtype=np.uint32
+                            ),
+                        },
+                    }
                 }
             }
-        }
-    }
+        },
+    )

--- a/daskms/tests/test_dataset_schema.py
+++ b/daskms/tests/test_dataset_schema.py
@@ -49,5 +49,6 @@ def test_unified_schema(ms):
             assert s.shape == var.shape[1:]
             assert np.dtype(s.dtype) == var.dtype
             assert isinstance(var.data, s.type)
+            assert s.attrs == var.attrs
 
     schema.to_arrow_schema()

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     from dask.utils import key_split
 
-from daskms.constants import DASKMS_PARTITION_KEY
+from daskms.constants import DASKMS_METADATA, DASKMS_PARTITION_KEY
 from daskms.dask_ms import xds_from_ms, xds_from_table, xds_to_table
 from daskms.query import orderby_clause, where_clause
 from daskms.table_proxy import TableProxy, taql_factory
@@ -143,7 +143,7 @@ def test_ms_update(ms, group_cols, index_cols, select_cols):
 
         (write,) = xds_to_table(nds, ms, ["STATE_ID", "DATA"])
 
-        for k, _ in nds.attrs[DASKMS_PARTITION_KEY]:
+        for k, _ in nds.attrs[DASKMS_METADATA][DASKMS_PARTITION_KEY]:
             assert getattr(write, k) == getattr(nds, k)
 
         writes.append(write)
@@ -319,7 +319,9 @@ def test_column_promotion(ms):
     for ds in xds:
         assert "DATA" in ds.data_vars
         assert "SCAN_NUMBER" in ds.attrs
-        assert ds.attrs[DASKMS_PARTITION_KEY] == (("SCAN_NUMBER", "int32"),)
+        assert ds.attrs[DASKMS_METADATA][DASKMS_PARTITION_KEY] == (
+            ("SCAN_NUMBER", "int32"),
+        )
 
 
 def test_read_array_names(ms):

--- a/daskms/tests/test_utils.py
+++ b/daskms/tests/test_utils.py
@@ -6,8 +6,10 @@ import platform
 
 import pytest
 
+from daskms.constants import DASKMS_METADATA, DASKMS_PARTITION_KEY, CASA_KEYWORDS
 from daskms.utils import (
     promote_columns,
+    merge_dicts,
     natural_order,
     table_path_split,
     requires,
@@ -96,3 +98,38 @@ def test_filter_kwargs():
         filter_kwargs(f, kwargs)
 
     assert "arg3" not in kwargs
+
+
+def test_merge_dicts():
+    lhs = {
+        DASKMS_METADATA: {
+            DASKMS_PARTITION_KEY: (("FIELD_ID", "int32"), ("DATA_DESC_ID", "int32")),
+            CASA_KEYWORDS: {"foo": "bar"},
+        },
+        "FIELD_ID": 0,
+        "DATA_DESC_ID": 0,
+    }
+
+    rhs = {
+        DASKMS_METADATA: {
+            CASA_KEYWORDS: {"foo": "qux"},
+        },
+    }
+
+    assert merge_dicts(lhs, rhs) == {
+        DASKMS_METADATA: {
+            DASKMS_PARTITION_KEY: (("FIELD_ID", "int32"), ("DATA_DESC_ID", "int32")),
+            CASA_KEYWORDS: {"foo": "qux"},
+        },
+        "FIELD_ID": 0,
+        "DATA_DESC_ID": 0,
+    }
+
+    assert merge_dicts(lhs, rhs, prefer="left") == {
+        DASKMS_METADATA: {
+            DASKMS_PARTITION_KEY: (("FIELD_ID", "int32"), ("DATA_DESC_ID", "int32")),
+            CASA_KEYWORDS: {"foo": "bar"},
+        },
+        "FIELD_ID": 0,
+        "DATA_DESC_ID": 0,
+    }

--- a/daskms/utils.py
+++ b/daskms/utils.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from collections import OrderedDict
-from frozendict import frozendict
 import logging
 from pathlib import PurePath, Path
 import re
@@ -264,3 +263,31 @@ def filter_kwargs(func, kwargs):
             f"{unhandled_kwargs}.",
             UserWarning,
         )
+
+
+def merge_dicts(lhs, rhs, prefer="right"):
+    result = {}
+
+    for k in set(lhs) | set(rhs):
+        try:
+            lv = lhs[k]
+        except KeyError:
+            result[k] = rhs[k]
+            continue
+
+        try:
+            rv = rhs[k]
+        except KeyError:
+            result[k] = lv
+            continue
+
+        if isinstance(lv, dict) and isinstance(rv, dict):
+            result[k] = merge_dicts(lv, rv, prefer=prefer)
+        elif prefer == "right":
+            result[k] = rv
+        elif prefer == "left":
+            result[k] = lv
+        else:
+            raise ValueError(f"{k}: {lv} != {rv}")
+
+    return result

--- a/daskms/utils.py
+++ b/daskms/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from collections import OrderedDict
+from frozendict import frozendict
 import logging
 from pathlib import PurePath, Path
 import re
@@ -13,6 +14,7 @@ from dask.utils import funcname
 # The numpy module may disappear during interpreter shutdown
 # so explicitly import ndarray
 from numpy import ndarray
+import numpy as np
 
 from daskms.testing import in_pytest
 
@@ -23,6 +25,31 @@ def natural_order(key):
     return tuple(
         int(c) if c.isdigit() else c.lower() for c in re.split(r"(\d+)", str(key))
     )
+
+
+class Frozen:
+    __slots__ = ("value", "hash")
+
+    def __init__(self, value):
+        self.value = value
+        self.hash = hash(freeze(value))
+
+    def __hash__(self):
+        return self.hash
+
+    def __eq__(self, rhs):
+        try:
+            np.testing.assert_equal(self.value, rhs)
+        except AssertionError:
+            return False
+        else:
+            return True
+
+    def __str__(self):
+        return str(self.value)
+
+    def __repr__(self):
+        return repr(self.value)
 
 
 def arg_hasher(args):

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -10,7 +10,7 @@ import numpy as np
 import pyrap.tables as pt
 
 from daskms.columns import dim_extents_array
-from daskms.constants import DASKMS_PARTITION_KEY
+from daskms.constants import DASKMS_PARTITION_KEY, DASKMS_METADATA
 from daskms.dataset import Dataset
 from daskms.dataset_schema import DatasetSchema
 from daskms.descriptors.builder import AbstractDescriptorBuilder
@@ -690,7 +690,7 @@ def _write_datasets(
             write_vars[column] = (full_dims, write_col)
 
         # Transfer any partition information over to the write dataset
-        partition = ds.attrs.get(DASKMS_PARTITION_KEY, False)
+        partition = ds.attrs.get(DASKMS_METADATA, {}).get(DASKMS_PARTITION_KEY, False)
 
         if not partition:
             attrs = None


### PR DESCRIPTION
- Closes #253 

- [ ] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [ ] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
