### PR TITLE
Upgrade package versions to 2023 versions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Update calver versioned software such as dask and xarray to 2023 variants (:pr:`279`)
 * Remove unused requirements_dev.txt (:pr:`275`)
 * Support optional CASA columns  (:pr:`270`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ packages = [{include = "daskms"}]
 [tool.poetry.dependencies]
 python = "^3.8"
 appdirs = "^1.4.4"
-dask = {extras = ["array"], version = "^2022.9.1"}
+dask = {extras = ["array"], version = "^2023.1.0"}
 donfig = "^0.7.0"
 python-casacore = "^3.5.1"
-pyarrow = {version = "^9.0.0", optional=true}
+pyarrow = {version = "^12.0.0", optional=true}
 zarr = {version = "^2.12.0", optional=true}
-xarray = {version = "^2022.6.0", optional=true}
-s3fs = {version = "^2022.8.2", optional=true}
+xarray = {version = "^2023.01.0", optional=true}
+s3fs = {version = "^2023.1.0", optional=true}
 minio = {version = "^7.1.11", optional=true}
 pytest = {version = "^7.1.3", optional=true}
 


### PR DESCRIPTION
Closes #278 

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
