### PR TITLE
Change setmaxcachesize to require a read lock, not a write lock

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+X.Y.Z (YYYY-MM-DD)
+------------------
+* Change setmaxcachesize to require a read lock, not a write lock (:pr:`281`)
+
 0.2.16 (2023-05-26)
 ------------------
 * Update calver versioned software such as dask and xarray to 2023 variants (:pr:`279`)

--- a/daskms/table_proxy.py
+++ b/daskms/table_proxy.py
@@ -34,7 +34,7 @@ _proxied_methods = [
     # Modification
     ("addrows", WRITELOCK),
     ("addcols", WRITELOCK),
-    ("setmaxcachesize", WRITELOCK),
+    ("setmaxcachesize", READLOCK),
     # Reads
     ("getcol", READLOCK),
     ("getcolslice", READLOCK),


### PR DESCRIPTION
Closes #280 

Previously, `setmaxcachesize` was called with a write lock, but this was problematic for readonly tables as setmaxcachesize was called during read ops.

As `setmaxcachesize` only modifies the internal casacore column caching, this can safely  be made a read operation.

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
