### PR TITLE
Retain ROWID coordinates during MS conversion

### DIFF
--- a/daskms/apps/convert.py
+++ b/daskms/apps/convert.py
@@ -228,10 +228,6 @@ class Convert(Application):
 
         datasets = reader(args.input, chunks=args.chunks)
 
-        if isinstance(in_fmt, CasaFormat):
-            # Drop any ROWID columns
-            datasets = [ds.drop_vars("ROWID", errors="ignore") for ds in datasets]
-
         if exclude_columns := args.exclude.get("MAIN", False):
             datasets = [
                 ds.drop_vars(exclude_columns, errors="ignore") for ds in datasets
@@ -272,9 +268,6 @@ class Convert(Application):
                 datasets = [
                     ds.drop_vars(exclude_columns, errors="ignore") for ds in datasets
                 ]
-
-            if isinstance(in_fmt, CasaFormat):
-                datasets = [ds.drop_vars("ROWID", errors="ignore") for ds in datasets]
 
             writes.append(writer(datasets, out_store))
 

--- a/daskms/apps/tests/test_convert.py
+++ b/daskms/apps/tests/test_convert.py
@@ -49,6 +49,7 @@ def test_convert_application(tau_ms, format, tmp_path_factory):
     for ds in datasets:
         assert "MODEL_DATA" not in ds.data_vars
         assert "FLAG" in ds.data_vars
+        assert "ROWID" in ds.coords
 
     datasets = xds_from_storage_table(f"{str(OUTPUT)}::POINTING")
 


### PR DESCRIPTION
Removing the ROWID coordinate prevents newer formats from mapping back to CASA Measurement Sets.

- https://github.com/ratt-ru/QuartiCal/issues/287

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [ ] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
