### PR TITLE
Update minio server and client versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ on: [push, pull_request]
 
 env:
   POETRY_VERSION: 1.2.1
-  MINIO_SERVER_DOWNLOAD_URL: https://dl.min.io/server/minio/release/linux-amd64/archive/minio_20220917000945.0.0_amd64.deb
-  MINIO_CLIENT_DOWNLOAD_URL: https://dl.min.io/client/mc/release/linux-amd64/archive/mcli_20220916091647.0.0_amd64.deb
+  MINIO_SERVER_DOWNLOAD_URL: https://dl.min.io/server/minio/release/linux-amd64/archive/minio_20230907020502.0.0_amd64.deb
+  MINIO_CLIENT_DOWNLOAD_URL: https://dl.min.io/client/mc/release/linux-amd64/archive/mcli_20230907224855.0.0_amd64.deb
 
 jobs:
   check_skip:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+X.Y.Z (YYYY-MM-DD)
+------------------
+* Update minio server and client versions (:pr:`287`)
+
 0.2.17 (2023-08-02)
 ------------------
 * Change setmaxcachesize to require a read lock, not a write lock (:pr:`281`)

--- a/daskms/conftest.py
+++ b/daskms/conftest.py
@@ -342,6 +342,7 @@ def minio_admin(minio_client, minio_alias, minio_user_key):
     minio_admin.user_add(minio_user_key, minio_user_key)
     minio_admin.policy_set("readwrite", user=minio_user_key)
     yield minio_admin
+    minio_admin.user_remove(minio_user_key)
 
 
 @pytest.fixture


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
