### PR TITLE
Remove xarray from testing dependencies

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
-* Add experimental fragments functionality (:pr:`282`)
+* Add experimental fragments functionality (:pr:`282`, :pr:`291`)
 * Run CI weekly on Monday @ 2h30 am UTC (:pr:`288`)
 * Update minio server and client versions (:pr:`287`)
 * Retain ROWID coordinates during MS conversion (:pr:`286`)

--- a/daskms/experimental/fragments/tests/test_fragments.py
+++ b/daskms/experimental/fragments/tests/test_fragments.py
@@ -66,7 +66,7 @@ def test_fragment_with_update(ms, tmp_path_factory, group_cols):
     fragment_path = tmp_dir / "fragment.ms"
 
     updates = [
-        xds.assign({"DATA": (xds.DATA.dims, da.ones_like(xds.DATA.data))})
+        xds.assign(**{"DATA": (xds.DATA.dims, da.ones_like(xds.DATA.data))})
         for xds in reads
     ]
 
@@ -98,7 +98,7 @@ def test_nonoverlapping_parents(ms, tmp_path_factory, group_cols):
     fragment1_path = tmp_dir / "fragment1.ms"
 
     updates = [
-        xds.assign({"DATA": (xds.DATA.dims, da.zeros_like(xds.DATA.data))})
+        xds.assign(**{"DATA": (xds.DATA.dims, da.zeros_like(xds.DATA.data))})
         for xds in reads
     ]
 
@@ -113,7 +113,7 @@ def test_nonoverlapping_parents(ms, tmp_path_factory, group_cols):
     )
 
     updates = [
-        xds.assign({"UVW": (xds.UVW.dims, da.zeros_like(xds.UVW.data))})
+        xds.assign(**{"UVW": (xds.UVW.dims, da.zeros_like(xds.UVW.data))})
         for xds in fragment0_reads
     ]
 
@@ -147,7 +147,7 @@ def test_overlapping_parents(ms, tmp_path_factory, group_cols):
     fragment1_path = tmp_dir / "fragment1.ms"
 
     updates = [
-        xds.assign({"DATA": (xds.DATA.dims, da.ones_like(xds.DATA.data))})
+        xds.assign(**{"DATA": (xds.DATA.dims, da.ones_like(xds.DATA.data))})
         for xds in reads
     ]
 
@@ -162,7 +162,7 @@ def test_overlapping_parents(ms, tmp_path_factory, group_cols):
     )
 
     updates = [
-        xds.assign({"DATA": (xds.DATA.dims, da.zeros_like(xds.DATA.data))})
+        xds.assign(**{"DATA": (xds.DATA.dims, da.zeros_like(xds.DATA.data))})
         for xds in fragment0_reads
     ]
 
@@ -304,7 +304,7 @@ def test_subtable_fragment_with_update(spw_table, tmp_path_factory):
 
     updates = [
         xds.assign(
-            {"CHAN_FREQ": (xds.CHAN_FREQ.dims, da.ones_like(xds.CHAN_FREQ.data))}
+            **{"CHAN_FREQ": (xds.CHAN_FREQ.dims, da.ones_like(xds.CHAN_FREQ.data))}
         )
         for xds in reads
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ xarray = ["xarray"]
 zarr = ["zarr"]
 s3 = ["s3fs"]
 complete = ["s3fs", "pyarrow", "xarray", "zarr"]
-testing = ["minio", "pytest", "xarray"]
+testing = ["minio", "pytest"]
 
 [tool.poetry.group.dev.dependencies]
 tbump = "^6.9.0"


### PR DESCRIPTION
- Removes full xarray testing dependency introduced in #282.
- Fixes some test cases to work without xarray.

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
