### PR TITLE
Lazily load casacore.tables

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+X.Y.Z (YYYY-MM-DD)
+------------------
+* Lazily load casacore tables module (:pr:`294`)
+
 0.2.18 (2023-09-20)
 ------------------
 * Ignore non-existent columns (:pr:`290`)

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ xarray Datasets from CASA Tables
 
 Constructs xarray_ ``Datasets`` from CASA Tables via python-casacore_.
 The ``Variables`` contained in the ``Dataset`` are dask_ arrays backed by
-deferred calls to :code:`pyrap.tables.table.getcol`.
+deferred calls to :code:`casacore.tables.table.getcol`.
 
 Supports writing ``Variables`` back to the respective column in the Table.
 

--- a/daskms/apps/formats.py
+++ b/daskms/apps/formats.py
@@ -2,6 +2,8 @@ import abc
 from functools import partial
 from pathlib import Path
 
+from daskms.patterns import lazy_import
+
 CASA_INPUT_ONLY_ARGS = ("group_columns", "index_columns", "taql_where")
 
 
@@ -28,9 +30,9 @@ class TableFormat(abc.ABC):
 
         if typ == "casa":
             from daskms.table_proxy import TableProxy
-            import pyrap.tables as pt
+            import casacore.tables as ct
 
-            table_proxy = TableProxy(pt.table, store.root, readonly=True, ack=False)
+            table_proxy = TableProxy(ct.table, store.root, readonly=True, ack=False)
             keywords = table_proxy.getkeywords().result()
             subtables = CasaFormat.find_subtables(keywords)
 

--- a/daskms/conftest.py
+++ b/daskms/conftest.py
@@ -9,11 +9,9 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 import numpy as np
-import pyrap.tables as pt
 import pytest
 
 from daskms.testing import mark_in_pytest
-
 
 # content of conftest.py
 def pytest_configure(config):
@@ -35,6 +33,7 @@ def xms_always_gc():
 
 @pytest.fixture(scope="session")
 def big_ms(tmp_path_factory, request):
+    ct = pytest.importorskip("casacore.tables")
     msdir = tmp_path_factory.mktemp("big_ms_dir", numbered=False)
     fn = os.path.join(str(msdir), "big.ms")
     row = request.param
@@ -60,7 +59,7 @@ def big_ms(tmp_path_factory, request):
     data = rs.random_sample(data_shape) + rs.random_sample(data_shape) * 1j
 
     # Create the table
-    with pt.taql(create_table_query) as ms:
+    with ct.taql(create_table_query) as ms:
         ant1, ant2 = (a.astype(np.int32) for a in np.triu_indices(ant, 1))
         bl = ant1.shape[0]
         ant1 = np.repeat(ant1, (row + bl - 1) // bl)
@@ -88,6 +87,7 @@ def big_ms(tmp_path_factory, request):
 
 @pytest.fixture
 def ms(tmp_path_factory):
+    ct = pytest.importorskip("casacore.tables")
     msdir = tmp_path_factory.mktemp("msdir", numbered=True)
     fn = os.path.join(str(msdir), "test.ms")
 
@@ -124,7 +124,7 @@ def ms(tmp_path_factory):
     uvw = rs.random_sample((len(state), 3)).astype(np.float64)
 
     # Create the table
-    with pt.taql(create_table_query) as ms:
+    with ct.taql(create_table_query) as ms:
         ms.putcol("FIELD_ID", field)
         ms.putcol("DATA_DESC_ID", ddid)
         ms.putcol("ANTENNA1", ant1)
@@ -155,6 +155,7 @@ def spw_chan_freqs():
 @pytest.fixture
 def spw_table(tmp_path_factory, spw_chan_freqs):
     """Simulate a SPECTRAL_WINDOW table with two spectral windows"""
+    ct = pytest.importorskip("casacore.tables")
     spw_dir = tmp_path_factory.mktemp("spw_dir", numbered=True)
     fn = os.path.join(str(spw_dir), "SPECTRAL_WINDOW")
 
@@ -168,7 +169,7 @@ def spw_table(tmp_path_factory, spw_chan_freqs):
         len(spw_chan_freqs),
     )
 
-    with pt.taql(create_table_query) as spw:
+    with ct.taql(create_table_query) as spw:
         spw.putvarcol(
             "NUM_CHAN", {"r%d" % i: s.shape[0] for i, s in enumerate(spw_chan_freqs)}
         )
@@ -210,6 +211,7 @@ def wsrt_antenna_positions():
 
 @pytest.fixture
 def ant_table(tmp_path_factory, wsrt_antenna_positions):
+    ct = pytest.importorskip("casacore.tables")
     ant_dir = tmp_path_factory.mktemp("ant_dir", numbered=True)
     fn = os.path.join(str(ant_dir), "ANTENNA")
 
@@ -225,7 +227,7 @@ def ant_table(tmp_path_factory, wsrt_antenna_positions):
 
     names = ["ANTENNA-%d" % i for i in range(wsrt_antenna_positions.shape[0])]
 
-    with pt.taql(create_table_query) as ant:
+    with ct.taql(create_table_query) as ant:
         ant.putcol("POSITION", wsrt_antenna_positions)
         ant.putcol("NAME", names)
 

--- a/daskms/descriptors/ms.py
+++ b/daskms/descriptors/ms.py
@@ -2,7 +2,6 @@
 import logging
 
 import numpy as np
-import pyrap.tables as pt
 
 from daskms.columns import infer_dtype
 from daskms.descriptors.builder import (
@@ -10,6 +9,9 @@ from daskms.descriptors.builder import (
     AbstractDescriptorBuilder,
 )
 from daskms.dataset import data_var_dims, DimensionInferenceError
+from daskms.patterns import lazy_import
+
+ct = lazy_import("casacore.tables")
 
 
 log = logging.getLogger(__name__)
@@ -30,8 +32,8 @@ class MSDescriptorBuilder(AbstractDescriptorBuilder):
 
     def __init__(self, fixed=True):
         super(AbstractDescriptorBuilder, self).__init__()
-        self.DEFAULT_MS_DESC = pt.complete_ms_desc()
-        self.REQUIRED_FIELDS = set(pt.required_ms_desc().keys())
+        self.DEFAULT_MS_DESC = ct.complete_ms_desc()
+        self.REQUIRED_FIELDS = set(ct.required_ms_desc().keys())
         self.fixed = fixed
         self.ms_dims = None
 

--- a/daskms/descriptors/ms_subtable.py
+++ b/daskms/descriptors/ms_subtable.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
-import pyrap.tables as pt
-
 from daskms.descriptors.builder import (
     register_descriptor_builder,
     AbstractDescriptorBuilder,
 )
+from daskms.patterns import lazy_import
 from daskms.table_schemas import SUBTABLES
+
+ct = lazy_import("casacore.tables")
 
 
 @register_descriptor_builder("mssubtable")
@@ -18,8 +19,8 @@ class MSSubTableDescriptorBuilder(AbstractDescriptorBuilder):
             )
 
         self.subtable = subtable
-        self.DEFAULT_TABLE_DESC = pt.complete_ms_desc(subtable)
-        self.REQUIRED_FIELDS = set(pt.required_ms_desc(subtable).keys())
+        self.DEFAULT_TABLE_DESC = ct.complete_ms_desc(subtable)
+        self.REQUIRED_FIELDS = set(ct.required_ms_desc(subtable).keys())
 
     def default_descriptor(self):
         return self.DEFAULT_TABLE_DESC.copy()

--- a/daskms/descriptors/tests/test_default_builder.py
+++ b/daskms/descriptors/tests/test_default_builder.py
@@ -5,7 +5,6 @@ import os
 import dask.array as da
 import numpy as np
 from numpy.testing import assert_array_equal
-import pyrap.tables as pt
 import pytest
 
 from daskms.dataset import Variable
@@ -13,6 +12,9 @@ from daskms.descriptors.builder import (
     DefaultDescriptorBuilder,
     variable_column_descriptor,
 )
+from daskms.patterns import lazy_import
+
+ct = lazy_import("casacore.tables")
 
 
 @pytest.mark.parametrize(
@@ -38,7 +40,7 @@ def test_default_plugin(tmp_path, chunks):
     tab_desc = builder.descriptor(variables, default_desc)
     dminfo = builder.dminfo(tab_desc)
 
-    with pt.table(filename, tab_desc, dminfo=dminfo, ack=False) as T:
+    with ct.table(filename, tab_desc, dminfo=dminfo, ack=False) as T:
         T.addrows(10)
         assert set(variables.keys()) == set(T.colnames())
 
@@ -72,9 +74,9 @@ def test_variable_column_descriptor(chunks, dtype, tmp_path):
 
     # Create a new table with the column metadata
     fn = os.path.join(str(tmp_path), "test.ms")
-    tabdesc = pt.maketabdesc(column_meta)
+    tabdesc = ct.maketabdesc(column_meta)
 
-    with pt.table(fn, tabdesc, readonly=False, ack=False) as T:
+    with ct.table(fn, tabdesc, readonly=False, ack=False) as T:
         # Add rows
         T.addrows(shapes["row"])
 

--- a/daskms/descriptors/tests/test_ms_builder.py
+++ b/daskms/descriptors/tests/test_ms_builder.py
@@ -3,11 +3,13 @@
 import dask.array as da
 import numpy as np
 from numpy.testing import assert_array_equal
-import pyrap.tables as pt
 import pytest
 
 from daskms.dataset import Variable
 from daskms.descriptors.ms import MSDescriptorBuilder
+from daskms.patterns import lazy_import
+
+ct = lazy_import("casacore.tables")
 
 
 @pytest.fixture(
@@ -70,11 +72,11 @@ def test_ms_builder(tmp_path, variables, fixed):
     dminfo = builder.dminfo(tab_desc)
 
     # These columns must always be present on an MS
-    required_cols = {k for k in pt.required_ms_desc().keys() if not k.startswith("_")}
+    required_cols = {k for k in ct.required_ms_desc().keys() if not k.startswith("_")}
 
     filename = str(tmp_path / "test_plugin.ms")
 
-    with pt.table(filename, tab_desc, dminfo=dminfo, ack=False, nrow=10) as T:
+    with ct.table(filename, tab_desc, dminfo=dminfo, ack=False, nrow=10) as T:
         # We got required + the extra columns we asked for
 
         assert set(T.colnames()) == set.union(var_names, required_cols)

--- a/daskms/descriptors/tests/test_ms_subtable_builder.py
+++ b/daskms/descriptors/tests/test_ms_subtable_builder.py
@@ -2,12 +2,14 @@
 
 import dask.array as da
 import numpy as np
-import pyrap.tables as pt
 import pytest
 
 from daskms.dataset import Variable
 from daskms.descriptors.ms_subtable import MSSubTableDescriptorBuilder
+from daskms.patterns import lazy_import
 from daskms.table_schemas import SUBTABLES
+
+ct = lazy_import("casacore.tables")
 
 
 @pytest.mark.parametrize("table", SUBTABLES)
@@ -23,12 +25,12 @@ def test_ms_subtable_builder(tmp_path, table):
 
     # These columns must always be present on an MS
     required_cols = {
-        k for k in pt.required_ms_desc(table).keys() if not k.startswith("_")
+        k for k in ct.required_ms_desc(table).keys() if not k.startswith("_")
     }
 
     filename = str(tmp_path / (f"{table}.table"))
 
-    with pt.table(filename, tab_desc, dminfo=dminfo, ack=False) as T:
+    with ct.table(filename, tab_desc, dminfo=dminfo, ack=False) as T:
         T.addrows(10)
 
         # We got required + the extra columns we asked for

--- a/daskms/example_data.py
+++ b/daskms/example_data.py
@@ -2,8 +2,11 @@
 
 from tempfile import mkdtemp
 
+from daskms.patterns import lazy_import
+
 import numpy as np
-import pyrap.tables as pt
+
+ct = lazy_import("casacore.tables")
 
 
 def _ms_factory_impl(ms_name):
@@ -36,23 +39,23 @@ def _ms_factory_impl(ms_name):
     spw_chans = [16, 32]
     ddids = ([0, 0, 4], [1, 1, 6])
 
-    with pt.default_ms(ms_name, desc) as ms:
+    with ct.default_ms(ms_name, desc) as ms:
         # Populate ANTENNA table
-        with pt.table(ant_name, **kw) as A:
+        with ct.table(ant_name, **kw) as A:
             A.addrows(na)
             A.putcol("POSITION", rs.random_sample((na, 3)) * 10000)
             A.putcol("OFFSET", rs.random_sample((na, 3)))
             A.putcol("NAME", ["ANT-%d" % i for i in range(na)])
 
         # Populate POLARIZATION table
-        with pt.table(pol_name, **kw) as P:
+        with ct.table(pol_name, **kw) as P:
             for r, corr_type in enumerate(corr_types):
                 P.addrows(1)
                 P.putcol("NUM_CORR", np.array(len(corr_type))[None], startrow=r, nrow=1)
                 P.putcol("CORR_TYPE", np.array(corr_type)[None, :], startrow=r, nrow=1)
 
         # Populate SPECTRAL_WINDOW table
-        with pt.table(spw_name, **kw) as SPW:
+        with ct.table(spw_name, **kw) as SPW:
             freq_start = 0.856e9
             freq_end = 2 * 0.856e9
 
@@ -71,7 +74,7 @@ def _ms_factory_impl(ms_name):
                 )
 
         # Populate FIELD table
-        with pt.table(field_name, **kw) as F:
+        with ct.table(field_name, **kw) as F:
             fields = (["3C147", np.deg2rad([0, 60])], ["3C147", np.deg2rad([30, 45])])
 
             npoly = 1
@@ -86,7 +89,7 @@ def _ms_factory_impl(ms_name):
                     F.putcol(c, phase_dir[None, None, :], startrow=r, nrow=1)
 
         # Populate DATA_DESCRIPTION table
-        with pt.table(ddid_name, **kw) as D:
+        with ct.table(ddid_name, **kw) as D:
             for r, (spw_id, pol_id, _) in enumerate(ddids):
                 D.addrows(1)
                 D.putcol(

--- a/daskms/patterns.py
+++ b/daskms/patterns.py
@@ -1,5 +1,6 @@
 """Keep this file in sync with the codex-africanus version"""
 
+import importlib
 import inspect
 from inspect import getattr_static
 from threading import Lock
@@ -386,3 +387,8 @@ class LazyProxyMultiton(LazyProxy, metaclass=Multiton):
 
     See :class:`LazyProxy` and :class:`Multiton` for further details
     """
+
+
+def lazy_import(name):
+    """Lazily import module `name`"""
+    return LazyProxy(importlib.import_module, name)

--- a/daskms/reads.py
+++ b/daskms/reads.py
@@ -3,10 +3,10 @@
 import logging
 from pathlib import Path
 
+
 import dask
 import dask.array as da
 import numpy as np
-import pyrap.tables as pt
 
 from daskms.columns import (
     column_metadata,
@@ -15,6 +15,7 @@ from daskms.columns import (
     infer_dtype,
 )
 from daskms.constants import DASKMS_PARTITION_KEY
+from daskms.patterns import lazy_import
 from daskms.ordering import (
     ordering_taql,
     row_ordering,
@@ -30,6 +31,8 @@ from daskms.table_schemas import lookup_table_schema
 from daskms.utils import table_path_split
 
 _DEFAULT_ROW_CHUNKS = 10000
+
+ct = lazy_import("casacore.tables")
 
 log = logging.getLogger(__name__)
 
@@ -318,7 +321,7 @@ class DatasetFactory(object):
 
     def _table_proxy_factory(self):
         return TableProxy(
-            pt.table,
+            ct.table,
             self.table_path,
             ack=False,
             readonly=True,

--- a/daskms/tests/test_columns.py
+++ b/daskms/tests/test_columns.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-import pyrap.tables as pt
 import pytest
 
 from daskms.columns import (
@@ -11,8 +10,11 @@ from daskms.columns import (
     _PY_TO_TABLE,
     column_metadata,
 )
+from daskms.patterns import lazy_import
 from daskms.table_proxy import TableProxy
 from daskms.utils import assert_liveness
+
+ct = lazy_import("casacore.tables")
 
 
 @pytest.mark.parametrize("casa_type, numpy_type", list(_TABLE_TO_PY.items()))
@@ -52,7 +54,7 @@ def test_missing_valuetype():
     ],
 )
 def test_column_metadata(ms, column, shape, chunks, table_schema, dtype):
-    table_proxy = TableProxy(pt.table, ms, readonly=True, ack=False)
+    table_proxy = TableProxy(ct.table, ms, readonly=True, ack=False)
     assert_liveness(1, 1)
 
     try:

--- a/daskms/tests/test_dataset_keywords.py
+++ b/daskms/tests/test_dataset_keywords.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 
 import dask
-import pyrap.tables as pt
 import pytest
 
 from daskms.example_data import example_ms
 from daskms.table_proxy import TableProxy
 from daskms import xds_to_table, xds_from_ms
 from daskms.dataset import Dataset
+from daskms.patterns import lazy_import
+
+ct = lazy_import("casacore.tables")
 
 
 @pytest.fixture(scope="module")
@@ -23,7 +25,7 @@ def keyword_ms():
 @pytest.mark.parametrize("table_proxy", [True, False])
 def test_read_keywords(keyword_ms, table_kw, column_kw, table_proxy):
     # Create an example MS
-    with pt.table(keyword_ms, ack=False, readonly=True) as T:
+    with ct.table(keyword_ms, ack=False, readonly=True) as T:
         desc = T._getdesc(actual=True)
 
     ret = xds_from_ms(
@@ -69,7 +71,7 @@ def test_write_keywords(ms):
     assert isinstance(writes, Dataset)
     dask.compute(writes)
 
-    with pt.table(ms, ack=False, readonly=True) as T:
+    with ct.table(ms, ack=False, readonly=True) as T:
         assert T.getkeywords()["bob"] == "qux"
 
     # Add to column keywords
@@ -80,7 +82,7 @@ def test_write_keywords(ms):
     assert all(isinstance(w, Dataset) for w in writes)
     dask.compute(writes)
 
-    with pt.table(ms, ack=False, readonly=True) as T:
+    with ct.table(ms, ack=False, readonly=True) as T:
         assert T.getcolkeywords("STATE_ID")["bob"] == "qux"
 
     # Remove from column and table keywords
@@ -97,7 +99,7 @@ def test_write_keywords(ms):
     assert all(isinstance(w, Dataset) for w in writes)
     dask.compute(writes)
 
-    with pt.table(ms, ack=False, readonly=True) as T:
+    with ct.table(ms, ack=False, readonly=True) as T:
         assert "bob" not in T.getkeywords()
         assert "bob" not in T.getcolkeywords("STATE_ID")
 

--- a/daskms/tests/test_optional.py
+++ b/daskms/tests/test_optional.py
@@ -14,10 +14,12 @@ from pprint import pprint  # noqa
 
 import numpy as np
 from numpy.testing import assert_array_equal
-import pyrap.tables as pt
 import pytest
 
 from daskms.columns import infer_casa_type
+from daskms.patterns import lazy_import
+
+ct = lazy_import("casacore.tables")
 
 
 @pytest.mark.optional
@@ -44,10 +46,10 @@ def test_variable_column_dimensions(tmp_path, column, dtype):
         "name": column,
     }
 
-    table_desc = pt.maketabdesc([desc])
+    table_desc = ct.maketabdesc([desc])
     fn = os.path.join(str(tmp_path), "test.table")
 
-    with pt.table(fn, table_desc, nrow=10, ack=False) as T:
+    with ct.table(fn, table_desc, nrow=10, ack=False) as T:
         # Put 10 rows into the table
         T.putcol(column, np.zeros((10, 20, 30), dtype=dtype))
         assert T.getcol(column).shape == (10, 20, 30)
@@ -87,10 +89,10 @@ def test_variable_column_shapes(tmp_path, column, dtype):
         "name": column,
     }
 
-    table_desc = pt.maketabdesc([desc])
+    table_desc = ct.maketabdesc([desc])
     fn = os.path.join(str(tmp_path), "test.table")
 
-    with pt.table(fn, table_desc, nrow=10, ack=False) as T:
+    with ct.table(fn, table_desc, nrow=10, ack=False) as T:
         # Put 10 rows into the table
         T.putcol(column, np.zeros((10, 20, 30), dtype=dtype))
         assert T.getcol(column).shape == (10, 20, 30)
@@ -132,10 +134,10 @@ def test_fixed_column_shapes(tmp_path, column, dtype):
         "name": column,
     }
 
-    table_desc = pt.maketabdesc([desc])
+    table_desc = ct.maketabdesc([desc])
     fn = os.path.join(str(tmp_path), "test.table")
 
-    with pt.table(fn, table_desc, nrow=10, ack=False) as T:
+    with ct.table(fn, table_desc, nrow=10, ack=False) as T:
         # Put 10 rows into the table
         T.putcol(column, np.zeros((10, 20, 30), dtype=dtype))
         assert T.getcol(column).shape == (10, 20, 30)
@@ -172,10 +174,10 @@ def test_only_row_shape(tmp_path, column, dtype):
         "name": column,
     }
 
-    table_desc = pt.maketabdesc([desc])
+    table_desc = ct.maketabdesc([desc])
     fn = os.path.join(str(tmp_path), "test.table")
 
-    with pt.table(fn, table_desc, nrow=10, ack=False) as T:
+    with ct.table(fn, table_desc, nrow=10, ack=False) as T:
         # Put 10 rows into the table
         T.putcol(column, np.zeros(10, dtype=dtype))
         assert T.getcol(column).shape == (10,)
@@ -214,10 +216,10 @@ def test_scalar_ndim(tmp_path, column, dtype):
         "name": column,
     }
 
-    table_desc = pt.maketabdesc([desc])
+    table_desc = ct.maketabdesc([desc])
     fn = os.path.join(str(tmp_path), "test.table")
 
-    with pt.table(fn, table_desc, nrow=10, ack=False) as T:
+    with ct.table(fn, table_desc, nrow=10, ack=False) as T:
         for r in range(10):
             T.putcell(column, r, r)
 
@@ -250,7 +252,7 @@ def test_tiledstman(tmp_path, column, row, shape, dtype):
         "name": column,
     }
 
-    table_desc = pt.maketabdesc([desc])
+    table_desc = ct.maketabdesc([desc])
 
     tile_shape = tuple(reversed(shape)) + (row,)
 
@@ -265,7 +267,7 @@ def test_tiledstman(tmp_path, column, row, shape, dtype):
 
     fn = os.path.join(str(tmp_path), "test.table")
 
-    with pt.table(fn, table_desc, dminfo=dminfo, nrow=10, ack=False) as T:
+    with ct.table(fn, table_desc, dminfo=dminfo, nrow=10, ack=False) as T:
         dmg = T.getdminfo()["*1"]
         assert dmg["NAME"] == "BAZ-GROUP"
         assert_array_equal(dmg["SPEC"]["DEFAULTTILESHAPE"], tile_shape)
@@ -299,7 +301,7 @@ def test_tiledstman_addcols(tmp_path, column, row, shape, dtype):
         "name": column,
     }
 
-    table_desc = pt.maketabdesc([desc])
+    table_desc = ct.maketabdesc([desc])
 
     tile_shape = tuple(reversed(shape)) + (row,)
 
@@ -314,7 +316,7 @@ def test_tiledstman_addcols(tmp_path, column, row, shape, dtype):
 
     fn = os.path.join(str(tmp_path), "test.table")
 
-    with pt.table(fn, table_desc, dminfo=dminfo, nrow=10, ack=False) as T:
+    with ct.table(fn, table_desc, dminfo=dminfo, nrow=10, ack=False) as T:
         # Add a new FRED column
         desc = {
             "FRED": {

--- a/daskms/tests/test_ordering.py
+++ b/daskms/tests/test_ordering.py
@@ -3,9 +3,9 @@
 import dask
 import dask.array as da
 from numpy.testing import assert_array_equal
-import pyrap.tables as pt
 import pytest
 
+from daskms.patterns import lazy_import
 from daskms.table_proxy import TableProxy
 from daskms.ordering import (
     ordering_taql,
@@ -16,8 +16,11 @@ from daskms.ordering import (
 from daskms.utils import group_cols_str, index_cols_str, assert_liveness
 
 
+ct = lazy_import("casacore.tables")
+
+
 def table_proxy(ms):
-    return TableProxy(pt.table, ms, ack=False, lockoptions="user", readonly=True)
+    return TableProxy(ct.table, ms, ack=False, lockoptions="user", readonly=True)
 
 
 @pytest.mark.parametrize(

--- a/daskms/utils.py
+++ b/daskms/utils.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from collections import OrderedDict
+import importlib.util
 import logging
 from pathlib import PurePath, Path
 import re
+import sys
 import time
 import inspect
 import warnings

--- a/docs/concepts/pyarrays.rst
+++ b/docs/concepts/pyarrays.rst
@@ -20,7 +20,7 @@ Numpy arrays via the `python-casacore
 
 .. testcode::
 
-    import pyrap.tables as pt
+    import casacore.tables as pt
     from daskms.example_data import example_ms
 
     ms_filename = example_ms()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ testing = ["minio", "pytest"]
 tbump = "^6.9.0"
 pre-commit = "^2.20.0"
 black = "^22.8.0"
-mypy = "^1.6.1"
 
 [tool.poetry.group.docs.dependencies]
 furo = "^2022.9.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,12 @@ packages = [{include = "daskms"}]
 
 [tool.poetry.dependencies]
 python = "^3.8"
+arcae = {version = "^0.2.1", optional = true}
 appdirs = "^1.4.4"
 dask = {extras = ["array"], version = "^2023.1.0"}
 donfig = "^0.7.0"
 python-casacore = "^3.5.1"
-pyarrow = {version = "^12.0.0", optional=true}
+pyarrow = {version = "^13.0.0", optional=true}
 zarr = {version = "^2.12.0", optional=true}
 xarray = {version = "^2023.01.0", optional=true}
 s3fs = {version = "^2023.1.0", optional=true}
@@ -25,6 +26,7 @@ dask-ms = "daskms.apps.entrypoint:main"
 fragments = "daskms.apps.fragments:main"
 
 [tool.poetry.extras]
+v030 = ["arcae", "xarray"]
 arrow = ["pyarrow"]
 xarray = ["xarray"]
 zarr = ["zarr"]
@@ -36,6 +38,7 @@ testing = ["minio", "pytest"]
 tbump = "^6.9.0"
 pre-commit = "^2.20.0"
 black = "^22.8.0"
+mypy = "^1.6.1"
 
 [tool.poetry.group.docs.dependencies]
 furo = "^2022.9.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ packages = [{include = "daskms"}]
 
 [tool.poetry.dependencies]
 python = "^3.9, < 3.13"
-arcae = {version = "^0.2.1", optional = true}
 appdirs = "^1.4.4"
 dask = {extras = ["array"], version = "^2023.1.0"}
 donfig = "^0.7.0"
@@ -27,7 +26,6 @@ dask-ms = "daskms.apps.entrypoint:main"
 fragments = "daskms.apps.fragments:main"
 
 [tool.poetry.extras]
-v030 = ["arcae", "xarray"]
 arrow = ["pandas", "pyarrow"]
 xarray = ["xarray"]
 zarr = ["zarr"]


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
