### PR TITLE
Deprecate python 3.8 support and handle pyarrow 13.0.0 test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - name: Create Cache Hash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     - cron: '30 2 * * 1' # Every Monday @ 2h30am UTC
 
 env:
-  POETRY_VERSION: 1.2.1
+  POETRY_VERSION: 1.6.1
   MINIO_SERVER_DOWNLOAD_URL: https://dl.min.io/server/minio/release/linux-amd64/archive/minio_20230907020502.0.0_amd64.deb
   MINIO_CLIENT_DOWNLOAD_URL: https://dl.min.io/client/mc/release/linux-amd64/archive/mcli_20230907224855.0.0_amd64.deb
 
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Create Cache Hash
@@ -85,6 +85,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
+
+      - name: Setup a virtual environment appropriate to the python version
+        run: poetry env use python${{ matrix.python-version }}
 
       - name: Install dask-ms base
         run: poetry install --extras "testing arrow zarr"

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+X.Y.Z (YYYY-MM-DD)
+------------------
+* Deprecate Python 3.8 (:pr:`296`)
+* Temporarily add Pandas as an arrow extra dependency (:pr:`296`)
+
 0.2.18 (2023-09-20)
 ------------------
 * Ignore non-existent columns (:pr:`290`)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
-* Deprecate Python 3.8 (:pr:`296`)
+* Deprecate Python 3.8 support (:pr:`296`)
 * Temporarily add Pandas as an arrow extra dependency (:pr:`296`)
 
 0.2.18 (2023-09-20)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ appdirs = "^1.4.4"
 dask = {extras = ["array"], version = "^2023.1.0"}
 donfig = "^0.7.0"
 python-casacore = "^3.5.1"
-pyarrow = {version = "^12.0.0", optional=true}
+pyarrow = {version = "^13.0.0", optional = true}
 zarr = {version = "^2.12.0", optional=true}
 xarray = {version = "^2023.01.0", optional=true}
 s3fs = {version = "^2023.1.0", optional=true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.rst"
 packages = [{include = "daskms"}]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9, < 3.13"
 appdirs = "^1.4.4"
 dask = {extras = ["array"], version = "^2023.1.0"}
 donfig = "^0.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,17 +19,18 @@ xarray = {version = "^2023.01.0", optional=true}
 s3fs = {version = "^2023.1.0", optional=true}
 minio = {version = "^7.1.11", optional=true}
 pytest = {version = "^7.1.3", optional=true}
+pandas = {version = "^2.1.2", optional = true}
 
 [tool.poetry.scripts]
 dask-ms = "daskms.apps.entrypoint:main"
 fragments = "daskms.apps.fragments:main"
 
 [tool.poetry.extras]
-arrow = ["pyarrow"]
+arrow = ["pandas", "pyarrow"]
 xarray = ["xarray"]
 zarr = ["zarr"]
 s3 = ["s3fs"]
-complete = ["s3fs", "pyarrow", "xarray", "zarr"]
+complete = ["s3fs", "pandas", "pyarrow", "xarray", "zarr"]
 testing = ["minio", "pytest"]
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Works around:

- https://github.com/ratt-ru/dask-ms/issues/295

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
