### PR TITLE
Replace black with ruff in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,16 +2,14 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.5.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
--   repo: https://github.com/psf/black
-    rev: 22.8.0
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.3
     hooks:
-    -   id: black
-        language_version: python3
-        args:
-          - --target-version=py38
+    -   id: ruff-format
+        name: ruff format

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Replace black with ruff in pre-commit hooks (:pr:`297`)
 * Lazily load casacore tables module (:pr:`294`)
 * Deprecate Python 3.8 support (:pr:`296`)
 * Temporarily add Pandas as an arrow extra dependency (:pr:`296`)

--- a/daskms/apps/fragments.py
+++ b/daskms/apps/fragments.py
@@ -21,7 +21,6 @@ def fragments():
     default=False,
 )
 def stat(fragment_path, prune):
-
     ancestors = get_ancestry(fragment_path, only_required=prune)
 
     click.echo("Ancestry:")

--- a/daskms/conftest.py
+++ b/daskms/conftest.py
@@ -13,6 +13,7 @@ import pytest
 
 from daskms.testing import mark_in_pytest
 
+
 # content of conftest.py
 def pytest_configure(config):
     mark_in_pytest(True)

--- a/daskms/dataset.py
+++ b/daskms/dataset.py
@@ -491,7 +491,7 @@ else:
             data_vars = OrderedDict()
             rev_results = list(results[::-1])
 
-            for (dask_collection, k, v) in info:
+            for dask_collection, k, v in info:
                 if dask_collection:
                     fn, args = v
                     r = rev_results.pop()

--- a/daskms/experimental/arrow/reads.py
+++ b/daskms/experimental/arrow/reads.py
@@ -165,7 +165,6 @@ def partition_chunking(partition, fragment_rows, chunks):
     it = zip(chunk_intervals, chunk_intervals[1:])
 
     for c, (lower, upper) in enumerate(it):
-
         si = np.searchsorted(intervals, lower, side="right") - 1
         ei = np.searchsorted(intervals, upper, side="left")
 
@@ -191,7 +190,6 @@ def partition_chunking(partition, fragment_rows, chunks):
 
 
 def fragment_reader(fragments, ranges, column, shape, dtype):
-
     if len(fragments) > 1:  # Reading over multiple row_groups.
         arr = np.empty(shape, dtype=dtype)
         offset = 0
@@ -277,7 +275,6 @@ def xds_from_parquet(store, columns=None, chunks=None, **kwargs):
         partition_chunks = partition_chunking(p, fragment_rows, chunks)
 
         for pieces in partition_chunks.values():
-
             chunk_fragments = [fragments[i] for i, _ in pieces]
             chunk_ranges = [r for _, r in pieces]
             chunk_metas = [f.metadata for f in chunk_fragments]

--- a/daskms/experimental/arrow/tests/test_parquet.py
+++ b/daskms/experimental/arrow/tests/test_parquet.py
@@ -166,7 +166,6 @@ def test_xds_to_parquet_local(ms, tmp_path_factory, spw_table, ant_table):
 def test_xds_to_parquet_s3(
     ms, spw_table, ant_table, py_minio_client, minio_user_key, minio_url, s3_bucket_name
 ):
-
     py_minio_client.make_bucket(s3_bucket_name)
 
     store = DaskMSStore(
@@ -189,7 +188,6 @@ def test_xds_to_parquet_s3(
 
 @pytest.fixture(params=[1, 2, 3, 4])
 def parquet_ms(ms, tmp_path_factory, request):
-
     parquet_store = tmp_path_factory.mktemp("parquet") / "test.parquet"
 
     # Chunk in row so we can probe chunk behaviour on reads.
@@ -204,7 +202,6 @@ def parquet_ms(ms, tmp_path_factory, request):
 
 @pytest.mark.parametrize("rc", [1, 2, 3, 4])
 def test_xds_from_parquet_chunks(ms, parquet_ms, rc):
-
     xdsl = xds_from_parquet(parquet_ms, chunks={"row": rc})
 
     chunks = chain.from_iterable([xds.chunks["row"] for xds in xdsl])

--- a/daskms/experimental/arrow/writes.py
+++ b/daskms/experimental/arrow/writes.py
@@ -60,7 +60,6 @@ class ParquetFragment:
         return (ParquetFragment, (self.store, self.key, self.schema, self.dataset_id))
 
     def write(self, chunk, *data):
-
         table_path = (
             self.key if self.store.table else self.store.join(["MAIN", self.key])
         )

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -150,7 +150,6 @@ def prepare_zarr_group(dataset_id, dataset, store, rechunk=False):
 
 
 def get_group_chunks(group):
-
     group_chunks = {}
 
     for array in group.values():

--- a/daskms/experimental/zarr/tests/test_zarr.py
+++ b/daskms/experimental/zarr/tests/test_zarr.py
@@ -113,7 +113,6 @@ def test_metadata_consolidation(ms, ant_table, tmp_path_factory, consolidated):
 
 
 def zarr_tester(ms, spw_table, ant_table, zarr_store, spw_store, ant_store):
-
     ms_datasets = xds_from_ms(ms)
     spw_datasets = xds_from_table(spw_table, group_cols="__row__")
     ant_datasets = xds_from_table(ant_table)
@@ -292,7 +291,6 @@ def test_fasteners(ms, tmp_path_factory):
 
 
 def test_basic_roundtrip(tmp_path):
-
     path = tmp_path / "test.zarr"
 
     # We need >10 datasets to be sure roundtripping is consistent.

--- a/daskms/tests/test_storage.py
+++ b/daskms/tests/test_storage.py
@@ -12,7 +12,6 @@ except ImportError:
 
 @pytest.mark.skipif(xarray is None, reason="Need xarray to check equality.")
 def test_storage_ms(ms):
-
     oxdsl = xds_from_ms(ms)
 
     writes = xds_to_storage_table(oxdsl, ms)
@@ -28,7 +27,6 @@ def test_storage_ms(ms):
 
 @pytest.mark.skipif(xarray is None, reason="Need xarray to check equality.")
 def test_storage_zarr(ms, tmp_path_factory):
-
     zarr_store = tmp_path_factory.mktemp("zarr") / "test.zarr"
 
     oxdsl = xds_from_ms(ms)
@@ -52,7 +50,6 @@ def test_storage_zarr(ms, tmp_path_factory):
 
 @pytest.mark.skipif(xarray is None, reason="Need xarray to check equality.")
 def test_storage_parquet(ms, tmp_path_factory):
-
     parquet_store = tmp_path_factory.mktemp("parquet") / "test.parquet"
 
     oxdsl = xds_from_ms(ms)

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -522,7 +522,6 @@ def cached_row_order(rowid):
         if not layer_name.startswith("row-") and not layer_name.startswith(
             "group-rows-"
         ):
-
             log.warning(
                 "Unusual ROWID layer %s. "
                 "This is probably OK but "
@@ -539,7 +538,6 @@ def cached_row_order(rowid):
             layer_names[0].startswith("group-rows-")
             and layer_names[1].startswith("rechunk-merge-")
         ):
-
             log.warning(
                 "Unusual ROWID layers %s for "
                 "the group ordering case. "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ testing = ["minio", "pytest"]
 tbump = "^6.9.0"
 pre-commit = "^2.20.0"
 black = "^22.8.0"
+ipython = "^8.16.1"
+ipdb = "^0.13.13"
+ruff = "^0.1.3"
 
 [tool.poetry.group.docs.dependencies]
 furo = "^2022.9.15"
@@ -44,6 +47,23 @@ Sphinx = "^5.1.1"
 numpydoc = "^1.4.0"
 Pygments = "^2.13.0"
 sphinx-copybutton = "^0.5.0"
+
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+
+select = [
+    # flake8-builtins
+    "A",
+    # flake8-bugbear
+    "B",
+    # isort
+    "I001",
+    "I002",
+    # tidy imports
+    "TID"
+]
 
 [build-system]
 requires = ["setuptools", "poetry-core"]


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
