### PR TITLE
Use new minio.MinioAdmin client in test suite and update minio server version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,7 @@ on:
 
 env:
   POETRY_VERSION: 1.6.1
-  MINIO_SERVER_DOWNLOAD_URL: https://dl.min.io/server/minio/release/linux-amd64/archive/minio_20230907020502.0.0_amd64.deb
-  MINIO_CLIENT_DOWNLOAD_URL: https://dl.min.io/client/mc/release/linux-amd64/archive/mcli_20230907224855.0.0_amd64.deb
+  MINIO_SERVER_DOWNLOAD_URL: https://dl.min.io/server/minio/release/linux-amd64/archive/minio_20231111081441.0.0_amd64.deb
 
 jobs:
   check_skip:
@@ -38,7 +37,6 @@ jobs:
           export HASH=$(sha256sum <<EOT | cut -c -16
           ${{ env.POETRY_VERSION }}
           ${{ env.MINIO_SERVER_DOWNLOAD_URL }}
-          ${{ env.MINIO_CLIENT_DOWNLOAD_URL }}
           EOT
           )
           echo "INSTALL_CACHE_HASH=$HASH" >> $GITHUB_ENV
@@ -63,23 +61,18 @@ jobs:
       - name: Test poetry run
         run: poetry --version
 
-      - name: Install Minio Server and Client
+      - name: Install Minio Server
         if: steps.cache-installs.outputs.cache-hit != 'true'
         run: |
           cd /tmp
           wget -q -c ${{ env.MINIO_SERVER_DOWNLOAD_URL }} -O minio.deb
-          wget -q -c ${{ env.MINIO_CLIENT_DOWNLOAD_URL }} -O mcli.deb
           dpkg-deb --extract minio.deb /tmp/minio
-          dpkg-deb --extract mcli.deb /tmp/mcli
           mkdir -p "${HOME}/.local/bin"
           echo "${HOME}/.local/bin" >> $GITHUB_PATH
           install /tmp/minio/usr/local/bin/minio "${HOME}/.local/bin/minio"
-          install /tmp/mcli/usr/local/bin/mcli "${HOME}/.local/bin/mc"
 
       - name: Test minio run
-        run: |
-          minio --help
-          mc --help
+        run: minio --help
 
       - name: Checkout source
         uses: actions/checkout@v2

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Use new minio.MinioAdmin client in test suite and update minio server version (:pr:`298`)
 * Replace black with ruff in pre-commit hooks (:pr:`297`)
 * Lazily load casacore tables module (:pr:`294`)
 * Deprecate Python 3.8 support (:pr:`296`)

--- a/daskms/conftest.py
+++ b/daskms/conftest.py
@@ -312,17 +312,12 @@ def minio_server(tmp_path_factory):
 
 
 @pytest.fixture
-def minio_alias():
-    return "testcloud"
-
-
-@pytest.fixture
 def minio_user_key():
     return "abcdef1234567890"
 
 
 @pytest.fixture
-def minio_admin(minio_server, minio_alias, minio_user_key):
+def minio_admin(minio_server, minio_user_key):
     minio = pytest.importorskip("minio")
     credentials = pytest.importorskip("minio.credentials")
     minio_admin = minio.MinioAdmin(
@@ -338,7 +333,7 @@ def minio_admin(minio_server, minio_alias, minio_user_key):
 
 
 @pytest.fixture
-def py_minio_client(minio_admin, minio_alias, minio_user_key):
+def py_minio_client(minio_admin, minio_user_key):
     minio = pytest.importorskip("minio")
     parsed_url = urlparse(MINIO_URL)
     yield minio.Minio(

--- a/daskms/experimental/arrow/tests/test_parquet.py
+++ b/daskms/experimental/arrow/tests/test_parquet.py
@@ -173,7 +173,7 @@ def test_xds_to_parquet_s3(
         key=minio_user_key,
         secret=minio_user_key,
         client_kwargs={
-            "endpoint_url": minio_url.geturl(),
+            "endpoint_url": minio_url,
             "region_name": "af-cpt",
         },
     )

--- a/daskms/experimental/zarr/tests/test_zarr.py
+++ b/daskms/experimental/zarr/tests/test_zarr.py
@@ -193,7 +193,7 @@ def test_xds_to_zarr_s3(
         key=minio_user_key,
         secret=minio_user_key,
         client_kwargs={
-            "endpoint_url": minio_url.geturl(),
+            "endpoint_url": minio_url,
             "region_name": "af-cpt",
         },
     )

--- a/daskms/tests/test_fsspec_store.py
+++ b/daskms/tests/test_fsspec_store.py
@@ -98,8 +98,6 @@ def test_store_subtable_access(tmp_path_factory):
 def test_minio_server(
     tmp_path,
     py_minio_client,
-    minio_admin,
-    minio_alias,
     minio_user_key,
     minio_url,
     s3_bucket_name,
@@ -126,8 +124,6 @@ def test_minio_server(
 def test_storage_options_from_config(
     tmp_path,
     py_minio_client,
-    minio_admin,
-    minio_alias,
     minio_user_key,
     minio_url,
     s3_bucket_name,

--- a/daskms/tests/test_fsspec_store.py
+++ b/daskms/tests/test_fsspec_store.py
@@ -95,6 +95,7 @@ def test_store_subtable_access(tmp_path_factory):
     assert (table_dir / "foo.txt").exists()
 
 
+@pytest.mark.skipif(s3fs is None, reason="s3fs not installed")
 def test_minio_server(
     tmp_path,
     py_minio_client,
@@ -109,7 +110,6 @@ def test_minio_server(
     py_minio_client.make_bucket(s3_bucket_name)
     py_minio_client.fput_object(s3_bucket_name, "stuff.txt", str(stuff))
 
-    s3fs = pytest.importorskip("s3fs")
     s3 = s3fs.S3FileSystem(
         key=minio_user_key,
         secret=minio_user_key,

--- a/daskms/tests/test_fsspec_store.py
+++ b/daskms/tests/test_fsspec_store.py
@@ -115,7 +115,7 @@ def test_minio_server(
     s3 = s3fs.S3FileSystem(
         key=minio_user_key,
         secret=minio_user_key,
-        client_kwargs={"endpoint_url": minio_url.geturl(), "region_name": "af-cpt"},
+        client_kwargs={"endpoint_url": minio_url, "region_name": "af-cpt"},
     )
 
     with s3.open(f"{s3_bucket_name}/stuff.txt", "rb") as f:
@@ -148,7 +148,7 @@ def test_storage_options_from_config(
         "key": minio_user_key,
         "secret": minio_user_key,
         "client_kwargs": {
-            "endpoint_url": minio_url.geturl(),
+            "endpoint_url": minio_url,
             "region_name": "af-south-1",
             "verify": False,
         },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ pyarrow = {version = "^13.0.0", optional=true}
 zarr = {version = "^2.12.0", optional=true}
 xarray = {version = "^2023.01.0", optional=true}
 s3fs = {version = "^2023.1.0", optional=true}
-minio = {version = "^7.1.11", optional=true}
+minio = {version = "^7.2.0", optional = true}
 pytest = {version = "^7.1.3", optional=true}
 pandas = {version = "^2.1.2", optional = true}
 


### PR DESCRIPTION
The latest minio python client changed `MinioAdmin` to directly communicate with minio servers, instead of via the `mc` client binary. This PR updates the testing framework to use the new interface and no longer installs `mc` when testing. The `minio` server version has been updated to 11 November 2023. 

Weekly cron job failed on newer python client here: https://github.com/ratt-ru/dask-ms/actions/runs/6844991970


- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
