### PR TITLE
Re-enable exceptions in multiprocessing test case

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+X.Y.Z (YYYY-MM-DD)
+------------------
+* Re-enable exceptions in multiprocessing test case (:pr:`302`)
+
 0.2.19 (2023-11-13)
 ------------------
 * Upgrade to pyarrow 14.0.1 (:pr:`299`)

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -275,7 +275,7 @@ def _proc_map_fn(args):
         write = xds_to_table(xds[i], ms, ["STATE_ID"])
         dask.compute(write)
     except Exception as e:
-        print(str(e))
+        raise e
 
     return True
 


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
