### PR TITLE
Update readthedocs python to 3.9 and poetry to 1.7.1

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Update readthedocs python version to 3.9 and poetry to 1.7.1 (:pr:`303`)
 * Re-enable exceptions in multiprocessing test case (:pr:`302`)
 * Fix auto-formatted f-strings (:pr:`301`)
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -10,7 +10,7 @@ build:
   tools: {python: "3.9"}
   jobs:
     post_install:
-      - pip install poetry==1.2.1
+      - pip install poetry==1.7.1
       - poetry config virtualenvs.create false
       - poetry install --with docs
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 # Set the version of Python and other tools you might need
 build:
   os: ubuntu-20.04
-  tools: {python: "3.8"}
+  tools: {python: "3.9"}
   jobs:
     post_install:
       - pip install poetry==1.2.1


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
