### PR TITLE
Bring back 3.8 support. Support casacore down to v3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: Create Cache Hash

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,8 +2,10 @@
 History
 =======
 
-X.Y.Z (YYYY-MM-DD)
+0.2.20 (2024-01-18)
 ------------------
+* Support casacore 3.3.1 and above (:pr:`306`)
+* Reinstate Python 3.8 LTS support (:pr:`306`)
 * Update readthedocs python version to 3.9 and poetry to 1.7.1 (:pr:`303`)
 * Re-enable exceptions in multiprocessing test case (:pr:`302`)
 * Fix auto-formatted f-strings (:pr:`301`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ xarray = {version = "^2023.01.0", optional=true}
 s3fs = {version = "^2023.1.0", optional=true}
 minio = {version = "^7.2.0", optional = true}
 pytest = {version = "^7.1.3", optional=true}
-pandas = {version = "^2.1.2", optional = true}
+pandas = {version = "^1.3.0", optional = true}
 
 [tool.poetry.scripts]
 dask-ms = "daskms.apps.entrypoint:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ testing = ["minio", "pytest"]
 tbump = "^6.9.0"
 pre-commit = "^2.20.0"
 black = "^22.8.0"
-ipython = "^8.16.1"
-ipdb = "^0.13.13"
+ipython = "^8.12.3"
+ipdb = "^0.13.9"
 ruff = "^0.1.3"
 
 [tool.poetry.group.docs.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,11 @@ readme = "README.rst"
 packages = [{include = "daskms"}]
 
 [tool.poetry.dependencies]
-python = "^3.9, < 3.13"
+python = "^3.8, < 3.13"
 appdirs = "^1.4.4"
 dask = {extras = ["array"], version = "^2023.1.0"}
 donfig = "^0.7.0"
-python-casacore = "^3.5.1"
+python-casacore = "^3.3.1"
 pyarrow = {version = "^14.0.1", optional = true}
 zarr = {version = "^2.12.0", optional=true}
 xarray = {version = "^2023.01.0", optional=true}


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
