### PR TITLE
Update calver dependencies to use inequalities

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,8 +4,8 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
-* Update dask to 2024.1.0 (:pr:`307`)
-* Update xarray to 2024.1.1 (:pr:`307`)
+* Update calver dependencies to use inequality, rather than caret dependency specifiers (:pr:`307`)
+* Update pre-commit to actions/python@v5.0.0 (:pr:`308`)
 * Update readthedocs python version to 3.9 and poetry to 1.7.1 (:pr:`303`)
 * Re-enable exceptions in multiprocessing test case (:pr:`302`)
 * Fix auto-formatted f-strings (:pr:`301`)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Update dask to 2024.1.0 (:pr:`307`)
+* Update xarray to 2024.1.1 (:pr:`307`)
 * Update readthedocs python version to 3.9 and poetry to 1.7.1 (:pr:`303`)
 * Re-enable exceptions in multiprocessing test case (:pr:`302`)
 * Fix auto-formatted f-strings (:pr:`301`)

--- a/daskms/tests/test_fsspec_store.py
+++ b/daskms/tests/test_fsspec_store.py
@@ -146,7 +146,6 @@ def test_storage_options_from_config(
         "client_kwargs": {
             "endpoint_url": minio_url,
             "region_name": "af-south-1",
-            "verify": False,
         },
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,12 @@ packages = [{include = "daskms"}]
 [tool.poetry.dependencies]
 python = "^3.9, < 3.13"
 appdirs = "^1.4.4"
-dask = {extras = ["array"], version = "^2023.1.0"}
+dask = {extras = ["array"], version = "^2024.1.0"}
 donfig = "^0.7.0"
 python-casacore = "^3.5.1"
 pyarrow = {version = "^14.0.1", optional = true}
 zarr = {version = "^2.12.0", optional=true}
-xarray = {version = "^2023.01.0", optional=true}
+xarray = {version = "^2024.1.1", optional=true}
 s3fs = {version = "^2023.1.0", optional=true}
 minio = {version = "^7.2.0", optional = true}
 pytest = {version = "^7.1.3", optional=true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ donfig = "^0.7.0"
 python-casacore = "^3.5.1"
 pyarrow = {version = "^14.0.1", optional = true}
 zarr = {version = "^2.12.0", optional=true}
-xarray = {version = ">= 2023.1.1", optional=true}
+xarray = {version = ">= 2023.01.0", optional=true}
 s3fs = {version = ">= 2023.1.0", optional=true}
 minio = {version = "^7.2.0", optional = true}
 pytest = {version = "^7.1.3", optional=true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ packages = [{include = "daskms"}]
 [tool.poetry.dependencies]
 python = "^3.9, < 3.13"
 appdirs = "^1.4.4"
-dask = {extras = ["array"], version = "^2024.1.0"}
+dask = {extras = ["array"], version = ">= 2023.1.1"}
 donfig = "^0.7.0"
 python-casacore = "^3.5.1"
 pyarrow = {version = "^14.0.1", optional = true}
 zarr = {version = "^2.12.0", optional=true}
-xarray = {version = "^2024.1.1", optional=true}
-s3fs = {version = "^2023.1.0", optional=true}
+xarray = {version = ">= 2023.1.1", optional=true}
+s3fs = {version = ">= 2023.1.0", optional=true}
 minio = {version = "^7.2.0", optional = true}
 pytest = {version = "^7.1.3", optional=true}
 pandas = {version = "^2.1.2", optional = true}


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
