### PR TITLE
Use JSON encoding for objects when writing zarr

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Use JSON codec for writing zarr strings (:pr:`310`)
 * Address warnings (:pr:`309`)
 
 0.2.20 (2024-01-30)

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -68,7 +68,7 @@ def zarr_chunks(column, dims, chunks):
 def create_array(ds_group, column, column_schema, schema_chunks, coordinate=False):
     import numcodecs
 
-    codec = numcodecs.Pickle() if column_schema.dtype == object else None
+    codec = numcodecs.JSON() if column_schema.dtype == object else None
 
     if column_schema.chunks is None:
         try:


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
