### PR TITLE
Move metadata consolidation into partition directories

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 X.Y.Z (YYYY-MM-DD)
 ------------------
 * Only test Github Action Push events on master (:pr:`313`)
+* Move consolidated metadata into partition subdirectories (:pr:`312`)
 * Set ``_ARRAY_DIMENSIONS`` attribute on Data Variables (:pr:`311`)
 * Use JSON codec for writing zarr strings (:pr:`310`)
 * Address warnings (:pr:`309`)

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -343,9 +343,9 @@ def xds_to_zarr(xds, store, columns=None, rechunk=False, consolidated=True, **kw
             }
 
         if consolidated:
-            table_path = store.table if store.table else "MAIN"
+            table_name = store.table if store.table else "MAIN"
             sep = store.fs.sep
-            store_path = f"{store.root}{sep}{table_path}{sep}{table_path}_{di}"
+            store_path = f"{store.root}{sep}{table_name}{sep}{table_name}_{di}"
             store_map = store.fs.get_mapper(store_path)
             zc.consolidate_metadata(store_map)
 

--- a/daskms/experimental/zarr/__init__.py
+++ b/daskms/experimental/zarr/__init__.py
@@ -109,6 +109,7 @@ def create_array(ds_group, column, column_schema, schema_chunks, coordinate=Fals
         column,
         column_schema.shape,
         chunks=zchunks,
+        fill_value=None,
         dtype=column_schema.dtype,
         object_codec=codec,
         exact=True,

--- a/daskms/experimental/zarr/tests/test_zarr.py
+++ b/daskms/experimental/zarr/tests/test_zarr.py
@@ -431,4 +431,4 @@ def test_xarray_reading_daskms_written_dataset(ms, tmp_path_factory):
 
     for i, mem_ds in enumerate(datasets):
         ds = xarray.open_zarr(path / "MAIN" / f"MAIN_{i}")
-        assert ds == mem_ds
+        assert ds.equals(mem_ds)

--- a/daskms/experimental/zarr/tests/test_zarr.py
+++ b/daskms/experimental/zarr/tests/test_zarr.py
@@ -75,11 +75,11 @@ def test_xds_to_zarr_coords(tmp_path_factory):
 
 @pytest.mark.parametrize("consolidated", [True, False])
 def test_metadata_consolidation(ms, ant_table, tmp_path_factory, consolidated):
-    zarr_dir = tmp_path_factory.mktemp("zarr_store") / "test.zarr"
-    ant_dir = zarr_dir.parent / f"{zarr_dir.name}::ANTENNA"
+    zarr_path = tmp_path_factory.mktemp("zarr_store") / "test.zarr"
+    ant_path = zarr_path.parent / f"{zarr_path.name}::ANTENNA"
 
-    main_store = DaskMSStore(zarr_dir)
-    ant_store = DaskMSStore(ant_dir)
+    main_store = DaskMSStore(zarr_path)
+    ant_store = DaskMSStore(ant_path)
 
     ms_datasets = xds_from_ms(ms)
     ant_datasets = xds_from_table(ant_table)
@@ -95,14 +95,14 @@ def test_metadata_consolidation(ms, ant_table, tmp_path_factory, consolidated):
     writes.extend(xds_to_zarr(ant_datasets, ant_store, consolidated=consolidated))
     dask.compute(writes)
 
-    assert main_store.exists("MAIN/.zmetadata") is consolidated
-    assert ant_store.exists(".zmetadata") is consolidated
+    assert main_store.exists("MAIN/MAIN_0/.zmetadata") is consolidated
+    assert ant_store.exists("ANTENNA_0/.zmetadata") is consolidated
 
     if consolidated:
-        with main_store.open("MAIN/.zmetadata") as f:
+        with main_store.open("MAIN/MAIN_0/.zmetadata") as f:
             assert "test-meta".encode("utf8") in f.read()
 
-        with ant_store.open(".zmetadata") as f:
+        with ant_store.open("ANTENNA_0/.zmetadata") as f:
             assert "test-meta".encode("utf8") in f.read()
 
     for ds in xds_from_zarr(main_store, consolidated=consolidated):


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
