### PR TITLE
Make dev and doc groups optional

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Make poetry dev and docs groups optional (:pr:`316`)
 * Only test Github Action Push events on master (:pr:`313`)
 * Move consolidated metadata into partition subdirectories (:pr:`312`)
 * Set ``_ARRAY_DIMENSIONS`` attribute on Data Variables (:pr:`311`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ s3 = ["s3fs"]
 complete = ["s3fs", "pandas", "pyarrow", "xarray", "zarr"]
 testing = ["minio", "pytest"]
 
+[tool.poetry.group.dev]
+optional = true
+
 [tool.poetry.group.dev.dependencies]
 tbump = "^6.9.0"
 pre-commit = "^2.20.0"
@@ -40,6 +43,9 @@ black = "^22.8.0"
 ipython = "^8.16.1"
 ipdb = "^0.13.13"
 ruff = "^0.1.3"
+
+[tool.poetry.group.docs]
+optional = true
 
 [tool.poetry.group.docs.dependencies]
 furo = "^2022.9.15"


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
