### PR TITLE
Add chunk specification to the katdal export

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Add chunk specification to ``dask-ms katdal import`` (:pr:`318`)
 * Add a ``dask-ms katdal import`` application for exporting SARAO archive data directly to zarr (:pr:`315`)
 * Define dask-ms command line applications with click (:pr:`317`)
 * Make poetry dev and docs groups optional (:pr:`316`)

--- a/daskms/apps/katdal_import.py
+++ b/daskms/apps/katdal_import.py
@@ -1,5 +1,7 @@
 import click
 
+from daskms.utils import parse_chunks_dict
+
 
 @click.group()
 @click.pass_context
@@ -58,10 +60,16 @@ class PolarisationListType(click.ParamType):
     "'K,B,G'. Use 'default' for L1 + L2 and 'all' for "
     "all available products.",
 )
-def _import(ctx, rdb_url, no_auto, pols_to_use, applycal, output_store):
+@click.option(
+    "--chunks",
+    callback=lambda c, p, v: parse_chunks_dict(v),
+    default="{time: 10}",
+    help="Chunking values to apply to each dimension",
+)
+def _import(ctx, rdb_url, output_store, no_auto, pols_to_use, applycal, chunks):
     """Export an observation in the SARAO archive to zarr formation
 
     RDB_URL is the SARAO archive link"""
     from daskms.experimental.katdal import katdal_import
 
-    katdal_import(rdb_url, output_store, no_auto, applycal)
+    katdal_import(rdb_url, output_store, no_auto, applycal, chunks)

--- a/daskms/tests/test_utils.py
+++ b/daskms/tests/test_utils.py
@@ -7,12 +7,21 @@ import platform
 import pytest
 
 from daskms.utils import (
+    parse_chunks_dict,
     promote_columns,
     natural_order,
     table_path_split,
     requires,
     filter_kwargs,
 )
+
+
+def test_parse_chunks_dict():
+    assert parse_chunks_dict("{row: 1000}") == {"row": 1000}
+    assert parse_chunks_dict("{row: 1000, chan: 64}") == {"row": 1000, "chan": 64}
+
+    with pytest.raises(ValueError):
+        parse_chunks_dict("row:1000}")
 
 
 def test_natural_order():

--- a/daskms/tests/test_utils.py
+++ b/daskms/tests/test_utils.py
@@ -19,8 +19,12 @@ from daskms.utils import (
 def test_parse_chunks_dict():
     assert parse_chunks_dict("{row: 1000}") == {"row": 1000}
     assert parse_chunks_dict("{row: 1000, chan: 64}") == {"row": 1000, "chan": 64}
+    assert parse_chunks_dict("{row: (10, 10), chan: (4, 4)}") == {
+        "row": (10, 10),
+        "chan": (4, 4),
+    }
 
-    with pytest.raises(ValueError):
+    with pytest.raises(SyntaxError):
         parse_chunks_dict("row:1000}")
 
 

--- a/daskms/utils.py
+++ b/daskms/utils.py
@@ -1,16 +1,12 @@
 # -*- coding: utf-8 -*-
 
 from collections import OrderedDict
-import importlib.util
 import logging
 from pathlib import PurePath, Path
 import re
-import sys
 import time
 import inspect
 import warnings
-
-from dask.utils import funcname
 
 # The numpy module may disappear during interpreter shutdown
 # so explicitly import ndarray
@@ -19,6 +15,28 @@ from numpy import ndarray
 from daskms.testing import in_pytest
 
 log = logging.getLogger(__name__)
+
+
+def parse_chunks_dict(chunks_str):
+    chunks_str = chunks_str.strip()
+    e = ValueError(
+        f"{chunks_str} is not of the form {{dim_1: size_1, ..., dim_n, size_n}}"
+    )
+    if not (chunks_str.startswith("{") and chunks_str.endswith("}")):
+        raise e
+
+    chunks = {}
+
+    for kvmap in chunks_str[1:-1].split(","):
+        try:
+            k, v = (p.strip() for p in kvmap.split(":"))
+            v = int(v)
+        except (IndexError, ValueError):
+            raise e
+        else:
+            chunks[k] = v
+
+    return chunks
 
 
 def natural_order(key):


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
