### PR TITLE
katdal import improvements

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Change `dask-ms katdal import` to `dask-ms import katdal` (:pr:`325`)
 * Configure dependabot (:pr:`319`)
 * Add chunk specification to ``dask-ms katdal import`` (:pr:`318`)
 * Add a ``dask-ms katdal import`` application for exporting SARAO archive data directly to zarr (:pr:`315`)

--- a/daskms/apps/entrypoint.py
+++ b/daskms/apps/entrypoint.py
@@ -3,7 +3,7 @@ import logging
 import click
 
 from daskms.apps.convert import convert
-from daskms.apps.katdal_import import katdal
+from daskms.apps.katdal_import import _import
 
 
 @click.group(name="dask-ms")
@@ -16,4 +16,4 @@ def main(ctx, debug):
 
 
 main.add_command(convert)
-main.add_command(katdal)
+main.add_command(_import)

--- a/daskms/apps/katdal_import.py
+++ b/daskms/apps/katdal_import.py
@@ -3,10 +3,10 @@ import click
 from daskms.utils import parse_chunks_dict
 
 
-@click.group()
+@click.group(name="import")
 @click.pass_context
-def katdal(ctx):
-    """subgroup for katdal commands"""
+def _import(ctx):
+    """subgroup for import commands"""
     pass
 
 
@@ -28,7 +28,7 @@ class PolarisationListType(click.ParamType):
         return value
 
 
-@katdal.command(name="import")
+@_import.command(name="katdal")
 @click.pass_context
 @click.argument("rdb_url", required=True)
 @click.option(
@@ -64,9 +64,9 @@ class PolarisationListType(click.ParamType):
     "--chunks",
     callback=lambda c, p, v: parse_chunks_dict(v),
     default="{time: 10}",
-    help="Chunking values to apply to each dimension",
+    help="Chunking values to apply to each dimension " "for e.g. {time: 20, chan: 64}",
 )
-def _import(ctx, rdb_url, output_store, no_auto, pols_to_use, applycal, chunks):
+def katdal(ctx, rdb_url, output_store, no_auto, pols_to_use, applycal, chunks):
     """Export an observation in the SARAO archive to zarr formation
 
     RDB_URL is the SARAO archive link"""


### PR DESCRIPTION
Swap katdal and import commands

- Instead of `dask-ms katdal import` we now do `dask-ms import katdal`

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
