### PR TITLE
DaskMSStore depends on fsspec >= 2022.7.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* DaskMSStore depends on ``fsspec >= 2022.7.0`` (:pr:`328`)
 * Optimise `broadcast_arrays` in katdal import (:pr:`326`)
 * Change `dask-ms katdal import` to `dask-ms import katdal` (:pr:`325`)
 * Configure dependabot (:pr:`319`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ minio = {version = "^7.2.0", optional = true}
 pytest = {version = "^7.1.3", optional=true}
 pandas = {version = "^2.1.2", optional = true}
 katdal = {version = "^0.22", optional = true}
+fsspec = ">=2022.7.0"
 
 [tool.poetry.scripts]
 dask-ms = "daskms.apps.entrypoint:main"


### PR DESCRIPTION
DaskMSStore depends on fsspec >= 2022.7.0 for it's functionality. We therefore specify `fsspec` as a full dependency.

Closes #327  

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
