### PR TITLE
Add an epoch argument to xds_{from,to}_zarr to uniquely identify datasets in a distributed context

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Add an epoch argument to xds_{from,to}_zarr to uniquely identify
+  datasets in a distributed context (:pr:`330`)
 * Improve table schema handling (:pr:`329`)
 * Identify channel and correlation-like dimensions in non-standard MS columns (:pr:`329`)
 * DaskMSStore depends on ``fsspec >= 2022.7.0`` (:pr:`328`)

--- a/daskms/table_proxy.py
+++ b/daskms/table_proxy.py
@@ -164,6 +164,7 @@ class TableProxyMetaClass(type):
                 return _table_cache[key]
             except KeyError:
                 instance = type.__call__(cls, *args, **kwargs)
+                instance._hashvalue = key
                 _table_cache[key] = instance
                 return instance
 
@@ -362,6 +363,9 @@ class TableProxy(object, metaclass=TableProxyMetaClass):
     @property
     def executor_key(self):
         return self._ex_key
+
+    def __hash__(self):
+        return self._hashvalue
 
     def __reduce__(self):
         """Defer to _map_create_proxy to support kwarg pickling"""


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
