### PR TITLE
Fix katdal import typos

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Fix katdal import typos (:pr:`331`)
 * Add an epoch argument to xds_{from,to}_zarr to uniquely identify
   datasets in a distributed context (:pr:`330`)
 * Improve table schema handling (:pr:`329`)

--- a/daskms/apps/katdal_import.py
+++ b/daskms/apps/katdal_import.py
@@ -67,7 +67,7 @@ class PolarisationListType(click.ParamType):
     help="Chunking values to apply to each dimension " "for e.g. {time: 20, chan: 64}",
 )
 def katdal(ctx, rdb_url, output_store, no_auto, pols_to_use, applycal, chunks):
-    """Export an observation in the SARAO archive to zarr formation
+    """Export an observation from the SARAO archive to zarr format
 
     RDB_URL is the SARAO archive link"""
     from daskms.experimental.katdal import katdal_import


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
