### PR TITLE
Bump donfig dependency to 0.8.0 due to install error with pip. 

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Bump donfig dependency to 0.8.0 due to install error with pip (:pr:332)
 * Fix katdal import typos (:pr:`331`)
 * Add an epoch argument to xds_{from,to}_zarr to uniquely identify
   datasets in a distributed context (:pr:`330`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [{include = "daskms"}]
 python = "^3.9, < 3.13"
 appdirs = "^1.4.4"
 dask = {extras = ["array"], version = ">= 2023.1.1"}
-donfig = "^0.8.0"
+donfig = ">=0.8.0"
 python-casacore = "^3.5.1"
 pyarrow = {version = "^14.0.1", optional = true}
 zarr = {version = "^2.12.0", optional=true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [{include = "daskms"}]
 python = "^3.9, < 3.13"
 appdirs = "^1.4.4"
 dask = {extras = ["array"], version = ">= 2023.1.1"}
-donfig = "^0.7.0"
+donfig = "^0.8.0"
 python-casacore = "^3.5.1"
 pyarrow = {version = "^14.0.1", optional = true}
 zarr = {version = "^2.12.0", optional=true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [{include = "daskms"}]
 python = "^3.9, < 3.13"
 appdirs = "^1.4.4"
 dask = {extras = ["array"], version = ">= 2023.1.1"}
-donfig = ">=0.8.0"
+donfig = ">= 0.8.0"
 python-casacore = "^3.5.1"
 pyarrow = {version = "^14.0.1", optional = true}
 zarr = {version = "^2.12.0", optional=true}


### PR DESCRIPTION
Error output with previous **pip install dask-ms**
 
"""
Collecting dask-ms
  Downloading dask_ms-0.2.20-py3-none-any.whl.metadata (6.4 kB)
Collecting appdirs<2.0.0,>=1.4.4 (from dask-ms)
  Downloading appdirs-1.4.4-py2.py3-none-any.whl.metadata (9.0 kB)
Collecting dask>=2023.1.1 (from dask[array]>=2023.1.1->dask-ms)
  Downloading dask-2024.5.1-py3-none-any.whl.metadata (3.8 kB)
Collecting donfig<0.8.0,>=0.7.0 (from dask-ms)
  Downloading donfig-0.7.0.tar.gz (32 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [16 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-ocz1hzpw/donfig_c7fcbbcfbc3a41dbae198dc134833f31/setup.py", line 32, in <module>
          version=versioneer.get_version(),
                  ^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-install-ocz1hzpw/donfig_c7fcbbcfbc3a41dbae198dc134833f31/versioneer.py", line 1522, in get_version
          return get_versions()["version"]
                 ^^^^^^^^^^^^^^
        File "/tmp/pip-install-ocz1hzpw/donfig_c7fcbbcfbc3a41dbae198dc134833f31/versioneer.py", line 1449, in get_versions
          cfg = get_config_from_root(root)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-install-ocz1hzpw/donfig_c7fcbbcfbc3a41dbae198dc134833f31/versioneer.py", line 344, in get_config_from_root
          parser = configparser.SafeConfigParser()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      AttributeError: module 'configparser' has no attribute 'SafeConfigParser'. Did you mean: 'RawConfigParser'?
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
"""