### PR TITLE
Restrict numpy to < 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ appdirs = "^1.4.4"
 dask = {extras = ["array"], version = ">= 2023.1.1"}
 donfig = ">= 0.8.0"
 python-casacore = "^3.5.1"
-pyarrow = {version = "^14.0.1", optional = true}
+numpy = "< 2.0.0"
+pyarrow = {version = ">= 14.0.1", optional = true}
 zarr = {version = "^2.12.0", optional=true}
 xarray = {version = ">= 2023.01.0", optional=true}
 s3fs = {version = ">= 2023.1.0", optional=true}


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
