### PR TITLE
Support numpy >= 2.0.0, python-casacore >= 3.6.1 and katdal >= 0.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,13 @@ name: Ubuntu CI
 
 on:
   push:
-    branches:
-    - master
-    tags:
-    - "*"
   pull_request:
   schedule:
     - cron: '30 2 * * 1,4' # Every Monday and Thursday @ 2h30am UTC
 
 env:
-  POETRY_VERSION: 1.6.1
-  MINIO_SERVER_DOWNLOAD_URL: https://dl.min.io/server/minio/release/linux-amd64/archive/minio_20231111081441.0.0_amd64.deb
+  POETRY_VERSION: 1.8.3
+  MINIO_SERVER_DOWNLOAD_URL: https://dl.min.io/server/minio/release/linux-amd64/archive/minio_20241029160148.0.0_amd64.deb
 
 jobs:
   check_skip:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: Ubuntu CI
 
-on:
-  push:
-  pull_request:
-  schedule:
-    - cron: '30 2 * * 1,4' # Every Monday and Thursday @ 2h30am UTC
+on: [push, pull_request]
+  # push:
+  # pull_request:
+  # schedule:
+  #   - cron: '30 2 * * 1,4' # Every Monday and Thursday @ 2h30am UTC
 
 env:
   POETRY_VERSION: 1.8.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: Ubuntu CI
 
-on: [push, pull_request]
-  # push:
-  # pull_request:
-  # schedule:
-  #   - cron: '30 2 * * 1,4' # Every Monday and Thursday @ 2h30am UTC
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '30 2 * * 1,4' # Every Monday and Thursday @ 2h30am UTC
 
 env:
   POETRY_VERSION: 1.8.3

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Pin minimum version of python-casacore to 3.6.1 (:pr:`337`)
+* Pin minimum version of NumPy to 2.0.0 (:pr:`337`)
 * Deprecate Python 3.9 support (:pr:`338`)
 * Update minio server version (:pr:`338`)
 * Remove complicated push setup in github action workflow (:pr:`338`)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Update minio server version (:pr:`338`)
+* Remove complicated push setup in github action workflow (:pr:`338`)
 * Fix date typo in HISTORY.rst (:pr:`336`)
 
 0.2.21 (2024-06-18)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Pin minimum version of katdal to 0.23 (:pr:`337`)
 * Pin minimum version of python-casacore to 3.6.1 (:pr:`337`)
 * Pin minimum version of NumPy to 2.0.0 (:pr:`337`)
 * Deprecate Python 3.9 support (:pr:`338`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ python = "^3.9, < 3.13"
 appdirs = "^1.4.4"
 dask = {extras = ["array"], version = ">= 2023.1.1"}
 donfig = ">= 0.8.0"
-python-casacore = "^3.6.1"
-numpy = ">= 2.0.0"
+python-casacore = "^3.5.1"
+numpy = "< 2.0.0"
 pyarrow = {version = ">= 14.0.1", optional = true}
 zarr = {version = "^2.12.0", optional=true}
 xarray = {version = ">= 2023.01.0", optional=true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ python = "^3.9, < 3.13"
 appdirs = "^1.4.4"
 dask = {extras = ["array"], version = ">= 2023.1.1"}
 donfig = ">= 0.8.0"
-python-casacore = "^3.5.1"
-numpy = "< 2.0.0"
+python-casacore = "^3.6.1"
+numpy = ">= 2.0.0"
 pyarrow = {version = ">= 14.0.1", optional = true}
 zarr = {version = "^2.12.0", optional=true}
 xarray = {version = ">= 2023.01.0", optional=true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ s3fs = {version = ">= 2023.1.0", optional=true}
 minio = {version = "^7.2.0", optional = true}
 pytest = {version = "^7.1.3", optional=true}
 pandas = {version = "^2.1.2", optional = true}
-katdal = {version = "^0.22", optional = true}
+katdal = {version = "^0.23", optional = true}
 fsspec = ">=2022.7.0"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
/cc @JSKenyon @landmanbester 

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [ ] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
