### PR TITLE
Fix the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,13 @@ name: Ubuntu CI
 
 on:
   push:
-    branches:
-    - master
-    tags:
-    - "*"
   pull_request:
   schedule:
     - cron: '30 2 * * 1,4' # Every Monday and Thursday @ 2h30am UTC
 
 env:
-  POETRY_VERSION: 1.6.1
-  MINIO_SERVER_DOWNLOAD_URL: https://dl.min.io/server/minio/release/linux-amd64/archive/minio_20231111081441.0.0_amd64.deb
+  POETRY_VERSION: 1.8.3
+  MINIO_SERVER_DOWNLOAD_URL: https://dl.min.io/server/minio/release/linux-amd64/archive/minio_20241029160148.0.0_amd64.deb
 
 jobs:
   check_skip:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - name: Create Cache Hash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Create Cache Hash

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Deprecate Python 3.9 support (:pr:`338`)
 * Update minio server version (:pr:`338`)
 * Remove complicated push setup in github action workflow (:pr:`338`)
 * Fix date typo in HISTORY.rst (:pr:`336`)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Update minio server version (:pr:`338`)
+* Remove complicated push setup in github action workflow (:pr:`338`)
 * Fix date typo in HISTORY.rst (:pr:`336`)
 
 0.2.21 (2024-06-18)

--- a/daskms/conftest.py
+++ b/daskms/conftest.py
@@ -297,8 +297,8 @@ def minio_server(tmp_path_factory):
     server_process = Popen(args, env=env, shell=False, stdout=PIPE, stderr=PIPE)
 
     try:
-        while line := server_process.stdout.readline():
-            if "Documentation: ".encode("utf-8") in line:
+        while line := server_process.stderr.readline():
+            if "Docs: ".encode("utf-8") in line:
                 break
 
         retcode = server_process.poll()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.rst"
 packages = [{include = "daskms"}]
 
 [tool.poetry.dependencies]
-python = "^3.9, < 3.13"
+python = "^3.10, < 3.13"
 appdirs = "^1.4.4"
 dask = {extras = ["array"], version = ">= 2023.1.1"}
 donfig = ">= 0.8.0"


### PR DESCRIPTION
- Update to the latest minio server
- Update poetry version

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
