### PR TITLE
Restrict dask < 2024.11.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Restrict dask < 2024.11.0 (:pr:`341`)
 * Use github action to install poetry (:pr:`340`)
 * Update readthedocs version (:pr:`339`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{include = "daskms"}]
 [tool.poetry.dependencies]
 python = "^3.10, < 3.13"
 appdirs = "^1.4.4"
-dask = {extras = ["array"], version = ">= 2023.1.1"}
+dask = {extras = ["array"], version = ">= 2023.1.1, < 2024.11.0"}
 donfig = ">= 0.8.0"
 python-casacore = "^3.6.1"
 numpy = ">= 2.0.0"


### PR DESCRIPTION
Temporary fix until we can address the fact that dask is changing it's underlying task representation.

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
