### PR TITLE
Allow Python 3.13 (keep dask-ms up to date)

### DIFF
--- a/daskms/expressions.py
+++ b/daskms/expressions.py
@@ -20,12 +20,12 @@ class Visitor(ast.NodeTransformer):
     if sys.version_info[1] >= 8:
 
         def visit_Constant(self, node):
-            return node.n
+            return node.value
 
     else:
 
         def visit_Num(self, node):
-            return node.n
+            return node.value
 
     def visit_Expr(self, node):
         return self.visit(node.value)

--- a/daskms/utils.py
+++ b/daskms/utils.py
@@ -42,7 +42,7 @@ class ChunkTransformer(ast.NodeTransformer):
         return tuple(self.visit(v) for v in node.elts)
 
     def visit_Constant(self, node):
-        return node.n
+        return node.value
 
 
 def parse_chunks_dict(chunks_str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.rst"
 packages = [{include = "daskms"}]
 
 [tool.poetry.dependencies]
-python = "^3.10, < 3.13"
+python = "^3.10, < 3.14"
 appdirs = "^1.4.4"
 dask = {extras = ["array"], version = ">= 2023.1.1, < 2024.11.0"}
 donfig = ">= 0.8.0"


### PR DESCRIPTION
I've updated some deprecated stuff (node.n -> node.value). And bumped python version requirements to <3.14. 

- [ ] Tests added / passed

One test fails :
```
========================================================================================================== FAILURES ==========================================================================================================
________________________________________________________________________________________________ test_multiton_serialisation _________________________________________________________________________________________________

clear_table_multiton_cache = None

    def test_multiton_serialisation(clear_table_multiton_cache):
        """Test multiton serialisation"""
        m1 = TableTestMultiton(factory, 1, b=3)
>       m2 = pickle.loads(pickle.dumps(m1))
E       TypeError: 'classmethod' object is not callable

daskms/tests/test_multiton_metaclass.py:152: TypeError
================================================================================================== short test summary info ===================================================================================================
FAILED daskms/tests/test_multiton_metaclass.py::test_multiton_serialisation - TypeError: 'classmethod' object is not callable

```
This failure seems to be in pickling/unpickling an object. Not sure this is a showstopper but if modern python doesn't allow this, then it should probably be noted. This has something to do with combining @property and @classmethod in MultitonMetaclass (this is deprecated in 3.11 - see here (https://stackoverflow.com/questions/79591814/why-does-python-disallow-chaining-descriptors-classmethod-and-property-sin)