### PR TITLE
Upgrade dask versions

### DIFF
--- a/daskms/optimisation.py
+++ b/daskms/optimisation.py
@@ -5,7 +5,8 @@ import uuid
 from weakref import WeakValueDictionary, WeakKeyDictionary
 
 import dask.array as da
-from dask.core import flatten, _execute_task
+from dask.core import flatten
+from dask.local import execute_task
 from dask.highlevelgraph import HighLevelGraph
 from dask.optimization import cull, inline
 
@@ -63,7 +64,7 @@ def cache_entry(cache, key, *task):
         try:
             return cache.cache[key]
         except KeyError:
-            cache.cache[key] = value = _execute_task(task, {})
+            cache.cache[key] = value = execute_task(task, {})
             return value
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,19 +10,19 @@ packages = [{include = "daskms"}]
 [tool.poetry.dependencies]
 python = "^3.10, < 3.14"
 appdirs = "^1.4.4"
-dask = {extras = ["array"], version = ">= 2023.1.1, < 2024.11.0"}
+dask = {extras = ["array"], version = ">= 2025.1.0"}
 donfig = ">= 0.8.0"
 python-casacore = "^3.7.0"
 numpy = ">= 2.0.0"
 pyarrow = {version = ">= 14.0.1", optional = true}
 zarr = {version = "^2.12.0", optional=true}
-xarray = {version = ">= 2023.01.0", optional=true}
-s3fs = {version = ">= 2023.1.0", optional=true}
+xarray = {version = ">= 2025.01.0", optional=true}
+s3fs = {version = ">= 2025.1.0", optional=true}
 minio = {version = "^7.2.0", optional = true}
 pytest = {version = "^7.1.3", optional=true}
 pandas = {version = "^2.1.2", optional = true}
 katdal = {version = "^0.23", optional = true}
-fsspec = ">=2022.7.0"
+fsspec = ">=2025.1.0"
 cacheout = "^0.16.0"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
- [ ] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [ ] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```


<!-- readthedocs-preview dask-ms start -->
----
📚 Documentation preview 📚: https://dask-ms--352.org.readthedocs.build/en/352/

<!-- readthedocs-preview dask-ms end -->