### PR TITLE
Support katdal data sources in xds_from_storage_ms

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 X.Y.Z (YYYY-MM-DD)
 ------------------
+* Support katdal data sources in xds_from_storage_ms (:pr:`353`)
 * Support Python 3.13 (:pr:`348`, :pr:`349`)
 * Implement a cacheout-based multiton, implementing a TTL (:pr:`344`)
 

--- a/daskms/experimental/katdal/__init__.py
+++ b/daskms/experimental/katdal/__init__.py
@@ -1,1 +1,1 @@
-from daskms.experimental.katdal.katdal_import import katdal_import
+from daskms.experimental.katdal.katdal_import import katdal_import, xds_from_katdal

--- a/daskms/experimental/katdal/katdal_import.py
+++ b/daskms/experimental/katdal/katdal_import.py
@@ -53,7 +53,7 @@ def xds_from_katdal(
     url_or_dataset: str | Dataset,
     applycal: str = "",
     no_auto: bool = True,
-    chunks: dict = {},
+    chunks: list[dict] | dict | None = None,
 ):
     if isinstance(url_or_dataset, Dataset):
         base_url = url_or_dataset

--- a/daskms/experimental/katdal/katdal_import.py
+++ b/daskms/experimental/katdal/katdal_import.py
@@ -1,8 +1,7 @@
+from __future__ import annotations
 import logging
 import os
 import urllib
-from threading import Lock
-import weakref
 
 import dask
 

--- a/daskms/experimental/katdal/msv2_facade.py
+++ b/daskms/experimental/katdal/msv2_facade.py
@@ -82,13 +82,13 @@ class XArrayMSv2Facade:
         self._cp_info = corrprod_index(dataset, self._pols_to_use, not no_auto)
 
         if not self._row_view:
-            self._chunks = chunks.copy() or DEFAULT_CHUNKS.copy()
+            self._chunks = (chunks or DEFAULT_CHUNKS).copy()
         else:
             # katdal's internal data shape is (time, chan, baseline*pol)
             # If chunking reasoning is row-based it's necessary to
             # derive a time based chunking from the row dimension
             # We cannot exactly supply the number of rows
-            chunks = chunks.copy() or {}
+            chunks = (chunks or {}).copy()
             row = chunks.pop("row", DEFAULT_TIME_CHUNKS * self.nbl)
             # We need at least one timestamps worth of rows
             row = max(row, self.nbl)

--- a/daskms/experimental/katdal/msv2_facade.py
+++ b/daskms/experimental/katdal/msv2_facade.py
@@ -502,6 +502,9 @@ class XArrayMSv2Facade:
 
         # Generate MAIN table xarray partition datasets
         for scan_index, scan_state, target in self._dataset.scans():
+            if scan_state == "slew":
+                continue
+
             # Retrieve existing field data, or create
             try:
                 field_id, _, _, _ = field_data[target.name]

--- a/daskms/experimental/katdal/msv2_facade.py
+++ b/daskms/experimental/katdal/msv2_facade.py
@@ -87,7 +87,8 @@ class XArrayMSv2Facade:
             # katdal's internal data shape is (time, chan, baseline*pol)
             # If chunking reasoning is row-based it's necessary to
             # derive a time based chunking from the row dimension
-            # We cannot exactly supply the number of rows
+            # We cannot always exactly supply the requested number of rows,
+            # as we always have to supply a multiple of the number of baselines
             chunks = (chunks or {}).copy()
             row = chunks.pop("row", DEFAULT_TIME_CHUNKS * self.nbl)
             # We need at least one timestamps worth of rows

--- a/daskms/experimental/katdal/tests/conftest.py
+++ b/daskms/experimental/katdal/tests/conftest.py
@@ -12,7 +12,7 @@ DEFAULT_PARAM = {"ntime": NTIME, "nchan": NCHAN, "nant": NANT, "dump_rate": DUMP
 
 
 @pytest.fixture(scope="session", params=[DEFAULT_PARAM])
-def dataset(request, tmp_path_factory):
+def katdal_dataset(request, tmp_path_factory):
     MockDataset = pytest.importorskip(
         "daskms.experimental.katdal.mock_dataset"
     ).MockDataset
@@ -48,10 +48,12 @@ def dataset(request, tmp_path_factory):
         bandwidth=856e6,
     )
 
-    return MockDataset(
+    ds = MockDataset(
         tmp_path_factory.mktemp("chunks"),
         targets,
         timestamps,
         antennas=MEERKAT_ANTENNA_DESCRIPTIONS[:nant],
         spw=spw,
     )
+
+    return ds

--- a/daskms/experimental/katdal/tests/test_chunkstore.py
+++ b/daskms/experimental/katdal/tests/test_chunkstore.py
@@ -115,7 +115,7 @@ def test_facade_chunking(
 ):
     expected_chunks.update((("corr", 4), ("uvw", 3)))
     row_dim = "row" in chunks
-    facade = XArrayMSv2Facade(katdal_dataset, not auto_corrs, row_dim, chunks)
+    facade = XArrayMSv2Facade(katdal_dataset, not auto_corrs, row_dim, [chunks])
     xds, _ = facade.xarray_datasets()
     assert len(xds) == 1
 

--- a/daskms/experimental/katdal/tests/test_chunkstore.py
+++ b/daskms/experimental/katdal/tests/test_chunkstore.py
@@ -2,23 +2,26 @@ import pytest
 
 xarray = pytest.importorskip("xarray")
 katdal = pytest.importorskip("katdal")
+katpoint = pytest.importorskip("katpoint")
 
 import dask
 import numpy as np
 from numpy.testing import assert_array_equal
 
 from daskms.experimental.zarr import xds_from_zarr, xds_to_zarr
-from daskms.experimental.katdal.msv2_facade import XarrayMSV2Facade
+from daskms.experimental.katdal.msv2_facade import XArrayMSv2Facade
 
 
 @pytest.mark.parametrize(
-    "dataset", [{"ntime": 20, "nchan": 16, "nant": 4}], indirect=True
+    "katdal_dataset", [{"ntime": 20, "nchan": 16, "nant": 4}], indirect=True
 )
 @pytest.mark.parametrize("auto_corrs", [True])
 @pytest.mark.parametrize("row_dim", [True, False])
 @pytest.mark.parametrize("out_store", ["output.zarr"])
-def test_chunkstore(tmp_path_factory, dataset, auto_corrs, row_dim, out_store):
-    facade = XarrayMSV2Facade(dataset, not auto_corrs, row_dim)
+def test_katdal_import(
+    tmp_path_factory, katdal_dataset, auto_corrs, row_dim, out_store
+):
+    facade = XArrayMSv2Facade(katdal_dataset, not auto_corrs, row_dim)
     xds, sub_xds = facade.xarray_datasets()
 
     # Reintroduce the shutil.rmtree and remote the tmp_path_factory
@@ -36,12 +39,12 @@ def test_chunkstore(tmp_path_factory, dataset, auto_corrs, row_dim, out_store):
     (read_xds,) = dask.compute(xds_from_zarr(out_store))
     read_xds = xarray.concat(read_xds, dim="row" if row_dim else "time")
 
-    test_data = dataset._test_data["correlator_data"]
+    test_data = katdal_dataset._test_data["correlator_data"]
     # Defer to ChunkStoreVisWeights application of weight scaling
-    test_weights = dataset._vfw.weights
+    test_weights = katdal_dataset._vfw.weights
     assert test_weights.shape == test_data.shape
     # Clamp test data to [0, 1]
-    test_flags = np.where(dataset._test_data["flags"] != 0, 1, 0)
+    test_flags = np.where(katdal_dataset._test_data["flags"] != 0, 1, 0)
     ntime, nchan, _ = test_data.shape
     (nbl,) = facade.cp_info.ant1_index.shape
     ncorr = read_xds.sizes["corr"]
@@ -59,3 +62,52 @@ def test_chunkstore(tmp_path_factory, dataset, auto_corrs, row_dim, out_store):
     assert_transposed_equal(test_data, read_xds.DATA.values)
     assert_transposed_equal(test_weights, read_xds.WEIGHT_SPECTRUM.values)
     assert_transposed_equal(test_flags, read_xds.FLAG.values)
+
+
+@pytest.mark.parametrize(
+    "katdal_dataset",
+    [
+        {
+            "ntime": 100,
+            "nchan": 16,
+            "nant": 4,
+            "targets": [
+                katpoint.Target(
+                    "J1939-6342 | PKS1934-638, radec bpcal, 19:39:25.03, -63:42:45.6"
+                )
+            ],
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "auto_corrs, chunks, expected_chunks",
+    [
+        # rows promoted to number of baselines if less than number of baselines
+        (True, {"row": 1, "chan": 16}, {"row": 10, "chan": 16}),
+        (False, {"row": 1, "chan": 16}, {"row": 6, "chan": 16}),
+        # rows round down to a multiple of number of baselines
+        (True, {"row": 11, "chan": 16}, {"row": 10, "chan": 16}),
+        (True, {"row": 19, "chan": 16}, {"row": 10, "chan": 16}),
+        (True, {"row": 21, "chan": 16}, {"row": 20, "chan": 16}),
+        (False, {"row": 11, "chan": 16}, {"row": 6, "chan": 16}),
+        (False, {"row": 12, "chan": 16}, {"row": 12, "chan": 16}),
+        (False, {"row": 19, "chan": 16}, {"row": 18, "chan": 16}),
+    ],
+)
+def test_facade_chunking(
+    tmp_path_factory, katdal_dataset, auto_corrs, chunks, expected_chunks
+):
+    expected_chunks.update((("corr", 4), ("uvw", 3)))
+    row_dim = "row" in chunks
+    facade = XArrayMSv2Facade(katdal_dataset, not auto_corrs, row_dim, chunks)
+    xds, _ = facade.xarray_datasets()
+    assert len(xds) == 2
+    assert xds[0].sizes["row"] == facade.nbl  # First dataset is a slew and rather small
+
+    from dask.array.core import normalize_chunks
+
+    for k, v in expected_chunks.items():
+        (expected_chunks[k],) = normalize_chunks(v, (xds[1].sizes[k],))
+
+    assert expected_chunks == xds[1].chunks, chunks

--- a/daskms/experimental/katdal/transpose.py
+++ b/daskms/experimental/katdal/transpose.py
@@ -23,8 +23,9 @@ import dask.array as da
 import numpy as np
 
 from numba import njit, literally
+from numba import types
 from numba.extending import overload, SentryLiteralArgs, register_jitable
-from numba.core.errors import TypingError
+from numba.core.errors import TypingError, RequireLiteralValue
 
 
 JIT_OPTIONS = {"nogil": True, "cache": True}
@@ -32,50 +33,41 @@ JIT_OPTIONS = {"nogil": True, "cache": True}
 
 @njit(**JIT_OPTIONS)
 def transpose_core(in_data, cp_index, data_type, row):
-    return transpose_impl(in_data, cp_index, literally(data_type), row)
+    return transpose_impl(in_data, cp_index, literally(data_type), literally(row))
 
 
-def transpose_impl(in_data, cp_index, data_type, row):
+def transpose_impl(in_data, cp_index, data_type_literal, row_literal):
     raise NotImplementedError
 
 
 @overload(transpose_impl, jit_options=JIT_OPTIONS, prefer_literal=True)
-def nb_transpose(in_data, cp_index, data_type, row):
-    SentryLiteralArgs(["data_type", "row"]).for_function(nb_transpose).bind(
-        in_data, cp_index, data_type, row
-    )
+def nb_transpose(in_data, cp_index, data_type_literal, row_literal):
+    if not isinstance(data_type_literal, types.StringLiteral):
+        raise RequireLiteralValue(
+            f"'data_type' {data_type_literal} must be a StringLiteral"
+        )
 
-    try:
-        data_type = data_type.literal_value
-    except AttributeError as e:
-        raise TypingError(f"data_type {data_type} is not a literal_value") from e
+    if not isinstance(row_literal, types.BooleanLiteral):
+        raise RequireLiteralValue(f"'row' {row_literal} must be a BooleanLiteral")
+
+    DATA_TYPE = data_type_literal.literal_value
+    ROW_DIM = row_literal.literal_value
+
+    if DATA_TYPE == "flags":
+        GET_VALUE = lambda v: v != 0
+        DEFAULT_VALUE = np.bool_(True)
+    elif DATA_TYPE == "vis":
+        GET_VALUE = lambda v: v
+        DEFAULT_VALUE = in_data.dtype(0 + 0j)
+    elif DATA_TYPE == "weights":
+        GET_VALUE = lambda v: v
+        DEFAULT_VALUE = in_data.dtype(0)
     else:
-        if not isinstance(data_type, str):
-            raise TypeError(f"data_type {data_type} is not a string: {type(data_type)}")
+        raise TypingError(f"data_type {DATA_TYPE} is not supported")
 
-    try:
-        row_dim = row.literal_value
-    except AttributeError as e:
-        raise TypingError(f"row {row} is not a literal_value") from e
-    else:
-        if not isinstance(row_dim, bool):
-            raise TypingError(f"row_dim {row_dim} is not a boolean {type(row_dim)}")
+    GET_VALUE = register_jitable(GET_VALUE)
 
-    if data_type == "flags":
-        get_value = lambda v: v != 0
-        default_value = np.bool_(True)
-    elif data_type == "vis":
-        get_value = lambda v: v
-        default_value = in_data.dtype(0 + 0j)
-    elif data_type == "weights":
-        get_value = lambda v: v
-        default_value = in_data.dtype(0)
-    else:
-        raise TypingError(f"data_type {data_type} is not supported")
-
-    get_value = register_jitable(get_value)
-
-    def impl(in_data, cp_index, data_type, row):
+    def impl(in_data, cp_index, data_type_literal, row_literal):
         n_time, n_chans, _ = in_data.shape
         n_bls, n_pol = cp_index.shape
         out_data = np.empty((n_time, n_bls, n_chans, n_pol), in_data.dtype)
@@ -91,13 +83,13 @@ def nb_transpose(in_data, cp_index, data_type, row):
                         for p in range(out_data.shape[3]):
                             idx = cp_index[b, p]
                             data = (
-                                get_value(in_data[t, c, idx])
+                                GET_VALUE(in_data[t, c, idx])
                                 if idx >= 0
-                                else default_value
+                                else DEFAULT_VALUE
                             )
                             out_data[t, b, c, p] = data
 
-        if row_dim:
+        if ROW_DIM:
             return out_data.reshape(n_time * n_bls, n_chans, n_pol)
 
         return out_data

--- a/daskms/experimental/katdal/transpose.py
+++ b/daskms/experimental/katdal/transpose.py
@@ -24,7 +24,7 @@ import numpy as np
 
 from numba import njit, literally
 from numba import types
-from numba.extending import overload, SentryLiteralArgs, register_jitable
+from numba.extending import overload, register_jitable
 from numba.core.errors import TypingError, RequireLiteralValue
 
 

--- a/daskms/experimental/katdal/transpose.py
+++ b/daskms/experimental/katdal/transpose.py
@@ -32,7 +32,7 @@ JIT_OPTIONS = {"nogil": True, "cache": True}
 
 @njit(**JIT_OPTIONS)
 def transpose_core(in_data, cp_index, data_type, row):
-    return transpose_impl(in_data, cp_index, data_type, row)
+    return transpose_impl(in_data, cp_index, literally(data_type), row)
 
 
 def transpose_impl(in_data, cp_index, data_type, row):
@@ -107,6 +107,7 @@ def nb_transpose(in_data, cp_index, data_type, row):
 
 def transpose(data, cp_index, data_type, row=False):
     ntime, _, _ = data.shape
+    t_chunks, _, _ = data.chunks
     nbl, ncorr = cp_index.shape
 
     if row:
@@ -123,7 +124,7 @@ def transpose(data, cp_index, data_type, row=False):
         ("time", "chan", "corrprod"),
         cp_index,
         None,
-        literally(data_type),
+        data_type,
         None,
         row,
         None,
@@ -133,6 +134,6 @@ def transpose(data, cp_index, data_type, row=False):
     )
 
     if row:
-        return output.rechunk({0: ntime * (nbl,)})
+        return output.rechunk({0: tuple(tc * nbl for tc in t_chunks)})
 
     return output

--- a/daskms/experimental/katdal/uvw.py
+++ b/daskms/experimental/katdal/uvw.py
@@ -41,6 +41,7 @@ def _uvw(target_description, time_utc, antennas, ant1, ant2, row):
 
 def uvw_coords(target, time_utc, antennas, cp_info, row=True):
     (ntime,) = time_utc.shape
+    (t_chunks,) = time_utc.chunks
     (nbl,) = cp_info.ant1_index.shape
 
     if row:
@@ -71,6 +72,6 @@ def uvw_coords(target, time_utc, antennas, cp_info, row=True):
     )
 
     if row:
-        return out.rechunk({0: ntime * (nbl,)})
+        return out.rechunk({0: tuple(tc * nbl for tc in t_chunks)})
 
     return out


### PR DESCRIPTION
- [ ] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [ ] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```


<!-- readthedocs-preview dask-ms start -->
----
📚 Documentation preview 📚: https://dask-ms--353.org.readthedocs.build/en/353/

<!-- readthedocs-preview dask-ms end -->