### PR TITLE
Fix typing and subtable url handling in katdal_import

### DIFF
--- a/daskms/experimental/katdal/katdal_import.py
+++ b/daskms/experimental/katdal/katdal_import.py
@@ -50,16 +50,19 @@ def default_output_name(url):
 
 @requires("pip install dask-ms[katdal]", import_error)
 def xds_from_katdal(
-    url_or_dataset: str | Dataset,
+    url_or_dataset: str | DataSet,
     applycal: str = "",
     no_auto: bool = True,
     chunks: list[dict] | dict | None = None,
 ):
-    if isinstance(url_or_dataset, Dataset):
+    if isinstance(url_or_dataset, DataSet):
         base_url = url_or_dataset
     elif isinstance(url_or_dataset, str):
-        base_url, subtable = url_or_dataset.split("::")
-        subtable = ""
+        try:
+            base_url, subtable = url_or_dataset.split("::", 1)
+        except ValueError:
+            base_url = url_or_dataset
+            subtable = ""
     else:
         raise TypeError(
             f"url_or_dataset {type(url_or_dataset)} must be a str or Dataset"


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
