### PR TITLE
Pass MinioAdmin.__init__ arguments  by kwarg

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+X.Y.Z (YYYY-MM-DD)
+------------------
+* Pass ``MinioAdmin.__init__`` arguments by kwarg (:pr:`358`)
+
 0.2.25 (2025-09-09)
 ------------------
 * Support katdal data sources in xds_from_storage_ms (:pr:`353`, :pr:`355`, :pr:`356`)

--- a/daskms/conftest.py
+++ b/daskms/conftest.py
@@ -321,8 +321,8 @@ def minio_admin(minio_server, minio_user_key):
     minio = pytest.importorskip("minio")
     credentials = pytest.importorskip("minio.credentials")
     minio_admin = minio.MinioAdmin(
-        urlparse(MINIO_URL).netloc,
-        credentials.StaticProvider(MINIO_ADMIN, MINIO_PASSWORD),
+        endpoint=urlparse(MINIO_URL).netloc,
+        credentials=credentials.StaticProvider(MINIO_ADMIN, MINIO_PASSWORD),
         secure=False,
     )
     # Add a user and give it readwrite access

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ pyarrow = {version = ">= 14.0.1", optional = true}
 zarr = {version = "^2.12.0", optional=true}
 xarray = {version = ">= 2023.01.0", optional=true}
 s3fs = {version = ">= 2023.1.0", optional=true}
-minio = {version = "^7.2.0", optional = true}
+minio = {version = "^7.2.0, <7.2.17", optional = true}
 pytest = {version = "^7.1.3", optional=true}
 pandas = {version = "^2.1.2", optional = true}
 katdal = {version = "^0.23", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ pyarrow = {version = ">= 14.0.1", optional = true}
 zarr = {version = "^2.12.0", optional=true}
 xarray = {version = ">= 2023.01.0", optional=true}
 s3fs = {version = ">= 2023.1.0", optional=true}
-minio = {version = "^7.2.0, <7.2.17", optional = true}
+minio = {version = "^7.2.0", optional = true}
 pytest = {version = "^7.1.3", optional=true}
 pandas = {version = "^2.1.2", optional = true}
 katdal = {version = "^0.23", optional = true}


### PR DESCRIPTION
Cron job failed on newer versions of minio (> 7.2.16) which require MinoAdmin arguments to be passed by kwarg.

- https://github.com/ratt-ru/dask-ms/actions/runs/18181868292


- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```


<!-- readthedocs-preview dask-ms start -->
----
📚 Documentation preview 📚: https://dask-ms--358.org.readthedocs.build/en/358/

<!-- readthedocs-preview dask-ms end -->