### PR TITLE
Support array API (PyTorch and CuPy) library writes 

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+0.2.31 (unreleased)
+-------------------
+* Fix writes for arrays from array API compatible libraries (JAX, CuPy,
+  PyTorch, etc.) using ``is_array_api_obj()`` for detection and
+  ``to_device_cpu()`` for safe GPU-to-CPU transfer before casacore
+  ``putcol`` calls, via a vendored subset of ``array-api-compat`` (:pr:`370`)
+
 0.2.30 (2026-04-20)
 -------------------
 * Support dask >= 2024.11.0 (TaskSpec refactor): replace removed ``_execute_task``
@@ -9,10 +16,6 @@ History
   ``optimisation.py``, handling mixed graphs where dask-ms tuple tasks and new-style
   Task objects coexist (:pr:`368`)
 * Remove ``dask < 2024.11.0`` upper-bound pin from ``pyproject.toml`` (:pr:`368`)
-* Fix writes for arrays from array API compatible libraries (JAX, CuPy,
-  PyTorch, etc.) using ``is_array_api_obj()`` for detection and
-  ``to_device_cpu()`` for safe GPU-to-CPU transfer before casacore
-  ``putcol`` calls, via a vendored subset of ``array-api-compat`` (:pr:`370`)
 
 0.2.29 (2026-01-19)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,9 +9,10 @@ History
   ``optimisation.py``, handling mixed graphs where dask-ms tuple tasks and new-style
   Task objects coexist (:pr:`368`)
 * Remove ``dask < 2024.11.0`` upper-bound pin from ``pyproject.toml`` (:pr:`368`)
-* Fix writes of arrays implementing the ``__array__`` protocol (JAX, CuPy,
-  PyTorch, etc.) to MS files by converting via ``np.asarray()`` before
-  casacore ``putcol`` calls (:pr:`370`)
+* Fix writes for arrays from array API compatible libraries (JAX, CuPy,
+  PyTorch, etc.) using ``is_array_api_obj()`` for detection and
+  ``to_device_cpu()`` for safe GPU-to-CPU transfer before casacore
+  ``putcol`` calls, via a vendored subset of ``array-api-compat`` (:pr:`370`)
 
 0.2.29 (2026-01-19)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,9 @@ History
   ``optimisation.py``, handling mixed graphs where dask-ms tuple tasks and new-style
   Task objects coexist (:pr:`368`)
 * Remove ``dask < 2024.11.0`` upper-bound pin from ``pyproject.toml`` (:pr:`368`)
+* Fix writes of arrays implementing the ``__array__`` protocol (JAX, CuPy,
+  PyTorch, etc.) to MS files by converting via ``np.asarray()`` before
+  casacore ``putcol`` calls (:pr:`370`)
 
 0.2.29 (2026-01-19)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,13 @@ History
   PyTorch, etc.) using ``is_array_api_obj()`` for detection and
   ``to_device_cpu()`` for safe GPU-to-CPU transfer before casacore
   ``putcol`` calls, via a vendored subset of ``array-api-compat`` (:pr:`370`)
+* Add mock-based unit tests for ``is_array_api_obj`` and ``to_device_cpu``
+  using fake CuPy/PyTorch stubs injected into ``sys.modules``; GPU mock
+  arrays raise on ``__array__`` unless the CPU transfer path is exercised
+  (:pr:`370`)
+* Document writing JAX, CuPy, and PyTorch arrays with dask-ms, including
+  the ``da.from_delayed`` pattern required for PyTorch due to
+  non-NumPy-compatible dtype objects (:pr:`370`)
 
 0.2.30 (2026-04-20)
 -------------------

--- a/daskms/array_api_utils.py
+++ b/daskms/array_api_utils.py
@@ -1,0 +1,63 @@
+"""
+Minimal vendored helpers from array-api-compat for array library detection
+and CPU transfer. Adapted from:
+https://github.com/data-apis/array-api-compat/blob/main/array_api_compat/common/_helpers.py
+
+MIT License
+
+Copyright (c) 2022 Consortium for Python Data API Standards
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+import sys
+from functools import lru_cache
+
+
+@lru_cache(100)
+def _issubclass_fast(cls, modname, clsname):
+    try:
+        mod = sys.modules[modname]
+    except KeyError:
+        return False
+    return issubclass(cls, getattr(mod, clsname))
+
+
+def is_array_api_obj(x):
+    """Return True if x is an array API compatible object."""
+    cls = type(x)
+    return (
+        hasattr(x, "__array_namespace__")
+        or _issubclass_fast(cls, "numpy", "ndarray")
+        or _issubclass_fast(cls, "cupy", "ndarray")
+        or _issubclass_fast(cls, "torch", "Tensor")
+        or _issubclass_fast(cls, "dask.array", "Array")
+        or _issubclass_fast(cls, "jax", "Array")
+        or _issubclass_fast(cls, "sparse", "SparseArray")
+    )
+
+
+def to_device_cpu(x):
+    """Move an array to CPU, returning the result."""
+    cls = type(x)
+    if _issubclass_fast(cls, "cupy", "ndarray"):
+        return x.get()
+    if _issubclass_fast(cls, "torch", "Tensor"):
+        return x.to("cpu")
+    return x

--- a/daskms/tests/test_array_api_utils.py
+++ b/daskms/tests/test_array_api_utils.py
@@ -34,7 +34,9 @@ def _make_fake_cupy():
             return self._data
 
         def __array__(self, dtype=None, copy=None):
-            raise RuntimeError("Cannot call __array__ on a GPU array — use .get() first")
+            raise RuntimeError(
+                "Cannot call __array__ on a GPU array — use .get() first"
+            )
 
         @property
         def shape(self):

--- a/daskms/tests/test_array_api_utils.py
+++ b/daskms/tests/test_array_api_utils.py
@@ -1,0 +1,263 @@
+"""
+Unit tests for daskms.array_api_utils.
+
+Uses fake module injection into sys.modules so that _issubclass_fast can
+match mock classes without requiring real GPU libraries to be installed.
+Each fixture restores sys.modules and clears the lru_cache afterwards.
+"""
+import sys
+import types
+
+import dask.array as da
+import numpy as np
+import pytest
+
+from daskms.array_api_utils import _issubclass_fast, is_array_api_obj, to_device_cpu
+
+
+# ── Fake module helpers ────────────────────────────────────────────────────────
+
+
+def _make_fake_cupy():
+    """Return (module, CpuArray, GpuArray) for a fake cupy."""
+    mod = types.ModuleType("cupy")
+
+    class GpuArray:
+        """Simulates a CuPy ndarray on GPU: __array__ raises, .get() works."""
+
+        __array_ufunc__ = None
+
+        def __init__(self, data):
+            self._data = np.asarray(data)
+
+        def get(self):
+            return self._data
+
+        def __array__(self, dtype=None, copy=None):
+            raise RuntimeError("Cannot call __array__ on a GPU array — use .get() first")
+
+        @property
+        def shape(self):
+            return self._data.shape
+
+        @property
+        def dtype(self):
+            return self._data.dtype
+
+    mod.ndarray = GpuArray
+    return mod, GpuArray
+
+
+def _make_fake_torch():
+    """Return (module, CpuTensor, GpuTensor) for a fake torch.
+
+    Both CpuTensor and GpuTensor are subclasses of mod.Tensor (the base class),
+    so _issubclass_fast(cls, "torch", "Tensor") matches both.  The GPU variant
+    raises on __array__; .to("cpu") downcasts to CpuTensor.
+    """
+    mod = types.ModuleType("torch")
+
+    class Tensor:
+        """Base class registered as mod.Tensor — mirrors torch.Tensor hierarchy."""
+
+        __array_ufunc__ = None
+
+        def __init__(self, data):
+            self._data = np.asarray(data)
+
+        @property
+        def shape(self):
+            return self._data.shape
+
+        @property
+        def dtype(self):
+            return self._data.dtype
+
+    class CpuTensor(Tensor):
+        """Simulates a CPU torch.Tensor: __array__ works, .to('cpu') is identity."""
+
+        def to(self, device):
+            if device == "cpu":
+                return self
+            raise RuntimeError(f"Fake tensor cannot move to {device!r}")
+
+        def __array__(self, dtype=None, copy=None):
+            return self._data if dtype is None else self._data.astype(dtype)
+
+    class GpuTensor(Tensor):
+        """Simulates a CUDA torch.Tensor: __array__ raises, .to('cpu') works."""
+
+        def to(self, device):
+            if device == "cpu":
+                return CpuTensor(self._data)
+            raise RuntimeError(f"Fake tensor cannot move to {device!r}")
+
+        def __array__(self, dtype=None, copy=None):
+            raise RuntimeError(
+                "Cannot call __array__ on a CUDA tensor — use .to('cpu') first"
+            )
+
+    mod.Tensor = Tensor  # issubclass check uses mod.Tensor; both subclasses match
+    return mod, CpuTensor, GpuTensor
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def fake_cupy():
+    """Inject a fake cupy module; restore sys.modules and clear cache after."""
+    mod, GpuArray = _make_fake_cupy()
+    original = sys.modules.get("cupy")
+    sys.modules["cupy"] = mod
+    _issubclass_fast.cache_clear()
+    yield mod, GpuArray
+    if original is None:
+        sys.modules.pop("cupy", None)
+    else:
+        sys.modules["cupy"] = original
+    _issubclass_fast.cache_clear()
+
+
+@pytest.fixture()
+def fake_torch():
+    """Inject a fake torch module; restore sys.modules and clear cache after."""
+    mod, CpuTensor, GpuTensor = _make_fake_torch()
+    original = sys.modules.get("torch")
+    sys.modules["torch"] = mod
+    _issubclass_fast.cache_clear()
+    yield mod, CpuTensor, GpuTensor
+    if original is None:
+        sys.modules.pop("torch", None)
+    else:
+        sys.modules["torch"] = original
+    _issubclass_fast.cache_clear()
+
+
+# ── is_array_api_obj ──────────────────────────────────────────────────────────
+
+
+class TestIsArrayApiObj:
+    def test_numpy_array(self):
+        assert is_array_api_obj(np.zeros(3))
+
+    def test_dask_array(self):
+        assert is_array_api_obj(da.zeros(3))
+
+    def test_plain_list_rejected(self):
+        assert not is_array_api_obj([1, 2, 3])
+
+    def test_scalar_rejected(self):
+        assert not is_array_api_obj(42.0)
+
+    def test_array_namespace_object(self):
+        class FakeArray:
+            def __array_namespace__(self, api_version=None):
+                return np
+
+        assert is_array_api_obj(FakeArray())
+
+    def test_fake_cupy_array(self, fake_cupy):
+        _, GpuArray = fake_cupy
+        arr = GpuArray(np.zeros(3))
+        assert is_array_api_obj(arr)
+
+    def test_fake_torch_cpu_tensor(self, fake_torch):
+        _, CpuTensor, _ = fake_torch
+        arr = CpuTensor(np.zeros(3))
+        assert is_array_api_obj(arr)
+
+    def test_fake_torch_gpu_tensor(self, fake_torch):
+        _, _, GpuTensor = fake_torch
+        arr = GpuTensor(np.zeros(3))
+        # GpuTensor is a subclass of mod.Tensor — detected as an array API object
+        assert is_array_api_obj(arr)
+
+    def test_fake_cupy_array_module_not_imported(self):
+        """Without cupy in sys.modules, a cupy-like class is not detected."""
+        _issubclass_fast.cache_clear()
+        original = sys.modules.pop("cupy", None)
+        try:
+            _, GpuArray = _make_fake_cupy()
+            arr = GpuArray(np.zeros(3))
+            # Neither __array_namespace__ nor sys.modules["cupy"] present
+            assert not is_array_api_obj(arr)
+        finally:
+            if original is not None:
+                sys.modules["cupy"] = original
+            _issubclass_fast.cache_clear()
+
+
+# ── to_device_cpu ─────────────────────────────────────────────────────────────
+
+
+class TestToDeviceCpu:
+    def test_numpy_passthrough(self):
+        arr = np.zeros((3, 4))
+        result = to_device_cpu(arr)
+        assert result is arr
+
+    def test_unknown_object_passthrough(self):
+        obj = object()
+        assert to_device_cpu(obj) is obj
+
+    def test_fake_cupy_calls_get(self, fake_cupy):
+        _, GpuArray = fake_cupy
+        data = np.array([1.0, 2.0, 3.0])
+        gpu_arr = GpuArray(data)
+
+        # Direct __array__ call must fail (simulating GPU restriction)
+        with pytest.raises(RuntimeError, match="GPU"):
+            np.asarray(gpu_arr)
+
+        # to_device_cpu must call .get() and return a numpy array
+        result = to_device_cpu(gpu_arr)
+        assert isinstance(result, np.ndarray)
+        np.testing.assert_array_equal(result, data)
+
+    def test_fake_cupy_result_is_numpy_castable(self, fake_cupy):
+        _, GpuArray = fake_cupy
+        gpu_arr = GpuArray(np.ones((2, 3), dtype=np.float32))
+        cpu = to_device_cpu(gpu_arr)
+        result = np.asarray(cpu)
+        assert result.shape == (2, 3)
+        assert result.dtype == np.float32
+
+    def test_fake_torch_gpu_calls_to_cpu(self, fake_torch):
+        _, CpuTensor, GpuTensor = fake_torch
+        data = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        gpu_tensor = GpuTensor(data)
+
+        # Direct __array__ call must fail
+        with pytest.raises(RuntimeError, match="CUDA"):
+            np.asarray(gpu_tensor)
+
+        # to_device_cpu must call .to("cpu") — result is CpuTensor, then castable
+        cpu_tensor = to_device_cpu(gpu_tensor)
+        assert isinstance(cpu_tensor, CpuTensor)
+        result = np.asarray(cpu_tensor)
+        np.testing.assert_array_equal(result, data)
+
+    def test_fake_torch_cpu_tensor_passthrough(self, fake_torch):
+        _, CpuTensor, _ = fake_torch
+        data = np.array([1.0, 2.0], dtype=np.float32)
+        cpu_tensor = CpuTensor(data)
+        # CpuTensor is an instance of mod.Tensor, so torch path matches it
+        result = to_device_cpu(cpu_tensor)
+        # .to("cpu") returns self — identity preserved
+        assert result is cpu_tensor
+
+    def test_cupy_not_imported_passthrough(self):
+        """If cupy is absent from sys.modules, to_device_cpu must not call .get()."""
+        _issubclass_fast.cache_clear()
+        original = sys.modules.pop("cupy", None)
+        try:
+            mod, GpuArray = _make_fake_cupy()
+            arr = GpuArray(np.zeros(3))
+            result = to_device_cpu(arr)
+            # Falls through to the no-op return — returns the original object
+            assert result is arr
+        finally:
+            if original is not None:
+                sys.modules["cupy"] = original
+            _issubclass_fast.cache_clear()

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import sys
+import types
 
 import dask
 import dask.array as da
@@ -13,6 +14,7 @@ try:
 except ImportError:
     from dask.utils import key_split
 
+from daskms.array_api_utils import _issubclass_fast
 from daskms.constants import DASKMS_PARTITION_KEY
 from daskms.dask_ms import xds_from_ms, xds_from_table, xds_to_table
 from daskms.patterns import lazy_import
@@ -565,3 +567,181 @@ def test_postprocess_ms(ms):
             "chan": (1,) * ds.sizes["chan"],
             "corr": (1,) * ds.sizes["corr"],
         }
+
+
+# ── GPU-mock write path tests ─────────────────────────────────────────────────
+#
+# Inject fake cupy / torch modules so that _issubclass_fast matches the mock
+# classes without requiring real GPU hardware or installed GPU libraries.
+# The GPU variants raise on __array__ until to_device_cpu is called.
+
+
+def _make_gpu_cupy_array(data):
+    """Return a GpuArray instance backed by a fresh fake-cupy module."""
+    mod = types.ModuleType("cupy")
+
+    class GpuArray:
+        # Tells numpy/dask this is an array-like object (needed for dask's is_arraylike),
+        # but opts out of ufunc dispatch (correct for GPU arrays that don't speak numpy).
+        __array_ufunc__ = None
+
+        def __init__(self, d):
+            self._data = np.asarray(d)
+
+        def get(self):
+            return self._data
+
+        def __array__(self, dtype=None, copy=None):
+            raise RuntimeError("GPU CuPy array: call .get() before __array__")
+
+        @property
+        def shape(self):
+            return self._data.shape
+
+        @property
+        def dtype(self):
+            return self._data.dtype
+
+        @property
+        def ndim(self):
+            return self._data.ndim
+
+        def __getitem__(self, item):
+            return GpuArray(self._data[item])
+
+        def __len__(self):
+            return len(self._data)
+
+    mod.ndarray = GpuArray
+    return mod, GpuArray(data)
+
+
+def _make_gpu_torch_tensor(data):
+    """Return a GpuTensor instance backed by a fresh fake-torch module."""
+    mod = types.ModuleType("torch")
+
+    class Tensor:
+        __array_ufunc__ = None
+
+        def __init__(self, d):
+            self._data = np.asarray(d)
+
+        @property
+        def shape(self):
+            return self._data.shape
+
+        @property
+        def dtype(self):
+            return self._data.dtype
+
+        def __getitem__(self, item):
+            return CpuTensor(self._data[item])
+
+        def __len__(self):
+            return len(self._data)
+
+    class CpuTensor(Tensor):
+        def to(self, device):
+            return self
+
+        def __array__(self, dtype=None, copy=None):
+            return self._data if dtype is None else self._data.astype(dtype)
+
+    class GpuTensor(Tensor):
+        def to(self, device):
+            if device == "cpu":
+                return CpuTensor(self._data)
+            raise RuntimeError(f"Cannot move to {device!r}")
+
+        def __array__(self, dtype=None, copy=None):
+            raise RuntimeError("GPU Torch tensor: call .to('cpu') before __array__")
+
+        def __getitem__(self, item):
+            return GpuTensor(self._data[item])
+
+    mod.Tensor = Tensor
+    return mod, GpuTensor(data)
+
+
+@pytest.fixture()
+def fake_cupy_ms(ms):
+    """Yield (ms_path, GpuArray-of-zeros) with fake cupy injected."""
+    xds = xds_from_ms(ms, columns=["DATA"], group_cols=[], chunks={"row": 2})[0]
+    dims = xds.sizes
+    data = np.zeros((dims["row"], dims["chan"], dims["corr"]), dtype=np.complex64)
+    mod, gpu_arr = _make_gpu_cupy_array(data)
+    original = sys.modules.get("cupy")
+    sys.modules["cupy"] = mod
+    _issubclass_fast.cache_clear()
+    yield ms, gpu_arr, data
+    if original is None:
+        sys.modules.pop("cupy", None)
+    else:
+        sys.modules["cupy"] = original
+    _issubclass_fast.cache_clear()
+
+
+@pytest.fixture()
+def fake_torch_ms(ms):
+    """Yield (ms_path, GpuTensor-of-zeros) with fake torch injected."""
+    xds = xds_from_ms(ms, columns=["DATA"], group_cols=[], chunks={"row": 2})[0]
+    dims = xds.sizes
+    data = np.zeros((dims["row"], dims["chan"], dims["corr"]), dtype=np.complex64)
+    mod, gpu_tensor = _make_gpu_torch_tensor(data)
+    original = sys.modules.get("torch")
+    sys.modules["torch"] = mod
+    _issubclass_fast.cache_clear()
+    yield ms, gpu_tensor, data
+    if original is None:
+        sys.modules.pop("torch", None)
+    else:
+        sys.modules["torch"] = original
+    _issubclass_fast.cache_clear()
+
+
+def _from_delayed_chunks(arr, row_chunks, shape_rest, dtype):
+    """Build a dask array from per-chunk delayed objects (avoids dtype introspection)."""
+    parts, row = [], 0
+    for rc in row_chunks:
+        chunk = arr[row : row + rc]
+        parts.append(
+            da.from_delayed(dask.delayed(chunk), shape=(rc,) + shape_rest, dtype=dtype)
+        )
+        row += rc
+    return da.concatenate(parts, axis=0)
+
+
+def test_fake_cupy_gpu_write(fake_cupy_ms):
+    """A fake CuPy GPU array must survive the full write path via to_device_cpu/.get()."""
+    ms_path, gpu_arr, expected = fake_cupy_ms
+    xds = xds_from_ms(ms_path, columns=["DATA"], group_cols=[], chunks={"row": 2})[0]
+    dims, chunks = xds.sizes, xds.chunks
+
+    da_data = da.from_array(gpu_arr, chunks=(chunks["row"], dims["chan"], dims["corr"]))
+    nds = xds.assign(DATA=(("row", "chan", "corr"), da_data))
+    (write,) = xds_to_table(nds, ms_path, ["DATA"])
+    dask.compute(write)
+
+    result = xds_from_ms(ms_path, columns=["DATA"], group_cols=[], chunks={"row": 2})[0]
+    assert_array_equal(result.DATA.values, expected)
+
+
+def test_fake_torch_gpu_write(fake_torch_ms):
+    """A fake PyTorch GPU tensor must survive the full write path via to_device_cpu/.to('cpu').
+
+    PyTorch tensors must be wrapped via from_delayed to avoid dtype introspection
+    at graph-construction time (torch dtypes are not numpy-compatible).
+    """
+    ms_path, gpu_tensor, expected = fake_torch_ms
+    xds = xds_from_ms(ms_path, columns=["DATA"], group_cols=[], chunks={"row": 2})[0]
+    dims, chunks = xds.sizes, xds.chunks
+
+    da_data = _from_delayed_chunks(
+        gpu_tensor, chunks["row"], (dims["chan"], dims["corr"]), expected.dtype
+    )
+    nds = xds.assign(DATA=(("row", "chan", "corr"), da_data))
+    (write,) = xds_to_table(nds, ms_path, ["DATA"])
+    dask.compute(write)
+
+    result = xds_from_ms(ms_path, columns=["DATA"], group_cols=[], chunks={"row": 2})[0]
+    assert_array_equal(result.DATA.values, expected)

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -368,10 +368,13 @@ def test_request_rowid(ms):
 
 
 class _ArrayLike:
-    """Minimal __array__ protocol object, standing in for JAX, CuPy, PyTorch, etc."""
+    """Minimal array API compatible object, standing in for JAX, CuPy, PyTorch, etc."""
 
     def __init__(self, data):
         self._data = np.asarray(data)
+
+    def __array_namespace__(self, api_version=None):
+        return np
 
     def __array__(self, dtype=None, copy=None):
         return self._data if dtype is None else self._data.astype(dtype)
@@ -396,7 +399,7 @@ class _ArrayLike:
 
 
 def test_array_protocol_write(ms):
-    """Arrays implementing __array__ (JAX, CuPy, PyTorch, ...) must be writable.
+    """Arrays implementing the array API (JAX, CuPy, PyTorch, ...) must be writable.
 
     Uses da.from_array: some libraries (JAX, zarr) are converted to numpy
     eagerly during graph construction, so this test covers the case where
@@ -426,8 +429,8 @@ def test_map_blocks_array_protocol_write(ms):
 
     This is the tab-sim / JAX pattern: a JAX-jitted function is wrapped in
     map_blocks, its output (a jax.Array) becomes the raw dask chunk and is
-    never eagerly converted to numpy.  putter_wrapper must handle it via the
-    __array__ protocol.
+    never eagerly converted to numpy.  putter_wrapper must handle it via
+    is_array_api_obj detection.
     """
     xds = xds_from_ms(ms, columns=["DATA"], group_cols=[], chunks={"row": 2})[0]
     dims = xds.sizes
@@ -507,7 +510,7 @@ def test_delayed_chain_array_protocol_write(ms):
 
     @dask.delayed
     def step2(arr):
-        return _ArrayLike(arr)  # non-numpy out — the final step returns array-protocol
+        return _ArrayLike(arr)  # non-numpy out — the final step returns an array API object
 
     parts, row = [], 0
     for rc in row_chunks:

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -32,6 +32,10 @@ ct = lazy_import("casacore.tables")
 PY_37_GTE = sys.version_info[:2] >= (3, 7)
 
 
+def _make_linear_ramp_array(shape, dtype):
+    return np.reshape(np.arange(np.prod(shape), dtype=dtype), shape)
+
+
 @pytest.mark.parametrize(
     "group_cols",
     [
@@ -412,7 +416,9 @@ def test_array_protocol_write(ms):
     chunks = xds.chunks
 
     array_like = _ArrayLike(
-        np.zeros((dims["row"], dims["chan"], dims["corr"]), dtype=np.complex64)
+        _make_linear_ramp_array(
+            (dims["row"], dims["chan"], dims["corr"]), dtype=np.complex64
+        )
     )
     da_data = da.from_array(
         array_like, chunks=(chunks["row"], dims["chan"], dims["corr"])
@@ -423,7 +429,9 @@ def test_array_protocol_write(ms):
     dask.compute(write)
 
     result = xds_from_ms(ms, columns=["DATA"], group_cols=[], chunks={"row": 2})[0]
-    assert_array_equal(result.DATA.data, np.zeros_like(result.DATA.values))
+    assert_array_equal(
+        result.DATA.data, _make_linear_ramp_array(result.DATA.shape, result.DATA.dtype)
+    )
 
 
 def test_map_blocks_array_protocol_write(ms):
@@ -438,7 +446,9 @@ def test_map_blocks_array_protocol_write(ms):
     dims = xds.sizes
     chunks = xds.chunks
 
-    np_data = np.zeros((dims["row"], dims["chan"], dims["corr"]), dtype=np.complex64)
+    np_data = _make_linear_ramp_array(
+        (dims["row"], dims["chan"], dims["corr"]), dtype=np.complex64
+    )
     da_input = da.from_array(
         np_data, chunks=(chunks["row"], dims["chan"], dims["corr"])
     )
@@ -468,7 +478,9 @@ def test_from_delayed_array_protocol_write(ms):
     dims = xds.sizes
     chunks = xds.chunks
 
-    np_data = np.zeros((dims["row"], dims["chan"], dims["corr"]), dtype=np.complex64)
+    np_data = _make_linear_ramp_array(
+        (dims["row"], dims["chan"], dims["corr"]), dtype=np.complex64
+    )
     row_chunks = chunks["row"]
     nchan, ncorr = dims["chan"], dims["corr"]
 
@@ -502,7 +514,9 @@ def test_delayed_chain_array_protocol_write(ms):
     dims = xds.sizes
     chunks = xds.chunks
 
-    np_data = np.zeros((dims["row"], dims["chan"], dims["corr"]), dtype=np.complex64)
+    np_data = _make_linear_ramp_array(
+        (dims["row"], dims["chan"], dims["corr"]), dtype=np.complex64
+    )
     row_chunks = chunks["row"]
     nchan, ncorr = dims["chan"], dims["corr"]
 
@@ -668,7 +682,10 @@ def fake_cupy_ms(ms):
     """Yield (ms_path, GpuArray-of-zeros) with fake cupy injected."""
     xds = xds_from_ms(ms, columns=["DATA"], group_cols=[], chunks={"row": 2})[0]
     dims = xds.sizes
-    data = np.zeros((dims["row"], dims["chan"], dims["corr"]), dtype=np.complex64)
+    data = _make_linear_ramp_array(
+        (dims["row"], dims["chan"], dims["corr"]), dtype=np.complex64
+    )
+
     mod, gpu_arr = _make_gpu_cupy_array(data)
     original = sys.modules.get("cupy")
     sys.modules["cupy"] = mod
@@ -686,7 +703,9 @@ def fake_torch_ms(ms):
     """Yield (ms_path, GpuTensor-of-zeros) with fake torch injected."""
     xds = xds_from_ms(ms, columns=["DATA"], group_cols=[], chunks={"row": 2})[0]
     dims = xds.sizes
-    data = np.zeros((dims["row"], dims["chan"], dims["corr"]), dtype=np.complex64)
+    data = _make_linear_ramp_array(
+        (dims["row"], dims["chan"], dims["corr"]), dtype=np.complex64
+    )
     mod, gpu_tensor = _make_gpu_torch_tensor(data)
     original = sys.modules.get("torch")
     sys.modules["torch"] = mod

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -510,7 +510,9 @@ def test_delayed_chain_array_protocol_write(ms):
 
     @dask.delayed
     def step2(arr):
-        return _ArrayLike(arr)  # non-numpy out — the final step returns an array API object
+        return _ArrayLike(
+            arr
+        )  # non-numpy out — the final step returns an array API object
 
     parts, row = [], 0
     for rc in row_chunks:

--- a/daskms/tests/test_ms_read_and_update.py
+++ b/daskms/tests/test_ms_read_and_update.py
@@ -5,8 +5,8 @@ import sys
 import dask
 import dask.array as da
 import numpy as np
-from numpy.testing import assert_array_equal
 import pytest
+from numpy.testing import assert_array_equal
 
 try:
     from dask.optimization import key_split
@@ -365,6 +365,166 @@ def test_mismatched_rowid(ms):
 
 def test_request_rowid(ms):
     xdsl = xds_from_ms(ms, columns=["TIME", "ROWID"])  # noqa
+
+
+class _ArrayLike:
+    """Minimal __array__ protocol object, standing in for JAX, CuPy, PyTorch, etc."""
+
+    def __init__(self, data):
+        self._data = np.asarray(data)
+
+    def __array__(self, dtype=None, copy=None):
+        return self._data if dtype is None else self._data.astype(dtype)
+
+    @property
+    def shape(self):
+        return self._data.shape
+
+    @property
+    def dtype(self):
+        return self._data.dtype
+
+    @property
+    def ndim(self):
+        return self._data.ndim
+
+    def __getitem__(self, item):
+        return self._data[item]
+
+    def __len__(self):
+        return len(self._data)
+
+
+def test_array_protocol_write(ms):
+    """Arrays implementing __array__ (JAX, CuPy, PyTorch, ...) must be writable.
+
+    Uses da.from_array: some libraries (JAX, zarr) are converted to numpy
+    eagerly during graph construction, so this test covers the case where
+    the chunk arrives at putter_wrapper already converted.
+    """
+    xds = xds_from_ms(ms, columns=["DATA"], group_cols=[], chunks={"row": 2})[0]
+    dims = xds.sizes
+    chunks = xds.chunks
+
+    array_like = _ArrayLike(
+        np.zeros((dims["row"], dims["chan"], dims["corr"]), dtype=np.complex64)
+    )
+    da_data = da.from_array(
+        array_like, chunks=(chunks["row"], dims["chan"], dims["corr"])
+    )
+
+    nds = xds.assign(DATA=(("row", "chan", "corr"), da_data))
+    (write,) = xds_to_table(nds, ms, ["DATA"])
+    dask.compute(write)
+
+    result = xds_from_ms(ms, columns=["DATA"], group_cols=[], chunks={"row": 2})[0]
+    assert_array_equal(result.DATA.data, np.zeros_like(result.DATA.values))
+
+
+def test_map_blocks_array_protocol_write(ms):
+    """da.map_blocks returning non-numpy chunks must be writable.
+
+    This is the tab-sim / JAX pattern: a JAX-jitted function is wrapped in
+    map_blocks, its output (a jax.Array) becomes the raw dask chunk and is
+    never eagerly converted to numpy.  putter_wrapper must handle it via the
+    __array__ protocol.
+    """
+    xds = xds_from_ms(ms, columns=["DATA"], group_cols=[], chunks={"row": 2})[0]
+    dims = xds.sizes
+    chunks = xds.chunks
+
+    np_data = np.zeros((dims["row"], dims["chan"], dims["corr"]), dtype=np.complex64)
+    da_input = da.from_array(
+        np_data, chunks=(chunks["row"], dims["chan"], dims["corr"])
+    )
+
+    # Simulate a JAX/torch function that returns non-numpy chunks
+    da_data = da.map_blocks(
+        lambda block: _ArrayLike(block), da_input, dtype=np_data.dtype
+    )
+
+    nds = xds.assign(DATA=(("row", "chan", "corr"), da_data))
+    (write,) = xds_to_table(nds, ms, ["DATA"])
+    dask.compute(write)
+
+    result = xds_from_ms(ms, columns=["DATA"], group_cols=[], chunks={"row": 2})[0]
+    assert_array_equal(result.DATA.data, np_data)
+
+
+def test_from_delayed_array_protocol_write(ms):
+    """da.from_delayed with non-numpy chunks must be writable.
+
+    This is the PyTorch pattern: libraries whose dtype objects are not
+    numpy-compatible must be wrapped via from_delayed with an explicit dtype.
+    The chunk is never inspected at graph construction time and arrives at
+    putter_wrapper unconverted.
+    """
+    xds = xds_from_ms(ms, columns=["DATA"], group_cols=[], chunks={"row": 2})[0]
+    dims = xds.sizes
+    chunks = xds.chunks
+
+    np_data = np.zeros((dims["row"], dims["chan"], dims["corr"]), dtype=np.complex64)
+    row_chunks = chunks["row"]
+    nchan, ncorr = dims["chan"], dims["corr"]
+
+    parts, row = [], 0
+    for rc in row_chunks:
+        chunk = _ArrayLike(np_data[row : row + rc])
+        parts.append(
+            da.from_delayed(
+                dask.delayed(chunk), shape=(rc, nchan, ncorr), dtype=np_data.dtype
+            )
+        )
+        row += rc
+    da_data = da.concatenate(parts, axis=0)
+
+    nds = xds.assign(DATA=(("row", "chan", "corr"), da_data))
+    (write,) = xds_to_table(nds, ms, ["DATA"])
+    dask.compute(write)
+
+    result = xds_from_ms(ms, columns=["DATA"], group_cols=[], chunks={"row": 2})[0]
+    assert_array_equal(result.DATA.data, np_data)
+
+
+def test_delayed_chain_array_protocol_write(ms):
+    """Chained dask.delayed returning non-numpy chunks must be writable.
+
+    Represents a deep computation graph where the final step of each chain
+    returns a non-numpy array-protocol object, as would happen when multiple
+    delayed JAX operations are composed before writing.
+    """
+    xds = xds_from_ms(ms, columns=["DATA"], group_cols=[], chunks={"row": 2})[0]
+    dims = xds.sizes
+    chunks = xds.chunks
+
+    np_data = np.zeros((dims["row"], dims["chan"], dims["corr"]), dtype=np.complex64)
+    row_chunks = chunks["row"]
+    nchan, ncorr = dims["chan"], dims["corr"]
+
+    @dask.delayed
+    def step1(arr):
+        return arr * 1.0  # numpy in
+
+    @dask.delayed
+    def step2(arr):
+        return _ArrayLike(arr)  # non-numpy out — the final step returns array-protocol
+
+    parts, row = [], 0
+    for rc in row_chunks:
+        chunk = np_data[row : row + rc]
+        result = step2(step1(chunk))
+        parts.append(
+            da.from_delayed(result, shape=(rc, nchan, ncorr), dtype=np_data.dtype)
+        )
+        row += rc
+    da_data = da.concatenate(parts, axis=0)
+
+    nds = xds.assign(DATA=(("row", "chan", "corr"), da_data))
+    (write,) = xds_to_table(nds, ms, ["DATA"])
+    dask.compute(write)
+
+    result = xds_from_ms(ms, columns=["DATA"], group_cols=[], chunks={"row": 2})[0]
+    assert_array_equal(result.DATA.data, np_data)
 
 
 def test_postprocess_ms(ms):

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -7,6 +7,7 @@ import dask.array as da
 import numpy as np
 from dask.highlevelgraph import HighLevelGraph
 
+from daskms.array_api_utils import is_array_api_obj, to_device_cpu
 from daskms.columns import dim_extents_array
 from daskms.constants import DASKMS_PARTITION_KEY
 from daskms.dataset import Dataset
@@ -186,8 +187,8 @@ def putter_wrapper(row_orders, *args):
                 "r%d" % (i + 1): data["r%d" % (s + 1)] for i, s in enumerate(resort)
             }
 
-    elif isinstance(data, np.ndarray) or hasattr(data, "__array__"):
-        data = np.asarray(data)
+    elif is_array_api_obj(data):
+        data = np.asarray(to_device_cpu(data))
         # Infer output shape
         out_shape = (1,) * len(data.shape)
 
@@ -406,8 +407,8 @@ def add_row_orders(data, table_proxy, prev=None):
     None
         Indicate that row resorting should not occur by default
     """
-    if isinstance(data, np.ndarray) or hasattr(data, "__array__"):
-        rows = len(data)
+    if is_array_api_obj(data):
+        rows = data.shape[0]
     elif isinstance(data, dict):
         rows = len(data)
     else:

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -4,24 +4,25 @@ import logging
 
 import dask
 import dask.array as da
-from dask.highlevelgraph import HighLevelGraph
 import numpy as np
+from dask.highlevelgraph import HighLevelGraph
 
 from daskms.columns import dim_extents_array
 from daskms.constants import DASKMS_PARTITION_KEY
 from daskms.dataset import Dataset
 from daskms.dataset_schema import DatasetSchema
 from daskms.descriptors.builder import AbstractDescriptorBuilder
-from daskms.descriptors.builder_factory import filename_builder_factory
-from daskms.descriptors.builder_factory import string_builder_factory
-from daskms.patterns import lazy_import
+from daskms.descriptors.builder_factory import (
+    filename_builder_factory,
+    string_builder_factory,
+)
 from daskms.optimisation import cached_array, inlined_array
 from daskms.ordering import row_run_factory
+from daskms.patterns import lazy_import
 from daskms.table import table_exists
 from daskms.table_executor import executor_key
-from daskms.table_proxy import TableProxy, WRITELOCK
+from daskms.table_proxy import WRITELOCK, TableProxy
 from daskms.utils import table_path_split
-
 
 ct = lazy_import("casacore.tables")
 
@@ -185,7 +186,8 @@ def putter_wrapper(row_orders, *args):
                 "r%d" % (i + 1): data["r%d" % (s + 1)] for i, s in enumerate(resort)
             }
 
-    elif isinstance(data, np.ndarray):
+    elif isinstance(data, np.ndarray) or hasattr(data, "__array__"):
+        data = np.asarray(data)
         # Infer output shape
         out_shape = (1,) * len(data.shape)
 
@@ -404,8 +406,8 @@ def add_row_orders(data, table_proxy, prev=None):
     None
         Indicate that row resorting should not occur by default
     """
-    if isinstance(data, np.ndarray):
-        rows = data.shape[0]
+    if isinstance(data, np.ndarray) or hasattr(data, "__array__"):
+        rows = np.asarray(data).shape[0]
     elif isinstance(data, dict):
         rows = len(data)
     else:

--- a/daskms/writes.py
+++ b/daskms/writes.py
@@ -407,7 +407,7 @@ def add_row_orders(data, table_proxy, prev=None):
         Indicate that row resorting should not occur by default
     """
     if isinstance(data, np.ndarray) or hasattr(data, "__array__"):
-        rows = np.asarray(data).shape[0]
+        rows = len(data)
     elif isinstance(data, dict):
         rows = len(data)
     else:

--- a/docs/tutorial/writes.rst
+++ b/docs/tutorial/writes.rst
@@ -209,3 +209,147 @@ Keywords can be added to the target table and columns:
     >>> xds_to_table(datasets, "test.ms", [],
                      table_keywords={"foo":"bar"},
                      column_keywords={"DATA": {"foo": "bar"}})
+
+
+.. _array-api-writes:
+
+Writing Arrays from Array API Compatible Libraries
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+dask-ms supports writing arrays from libraries that implement the
+`Python Array API standard (2021.12+) <https://data-apis.org/array-api/latest/>`_,
+including JAX, CuPy, and PyTorch.  Arrays are converted to NumPy inside
+each write task, so no changes to the :func:`~daskms.xds_to_table` call
+are needed.  GPU arrays are transferred to CPU automatically, one chunk
+at a time, avoiding a full device-to-host copy at graph-construction time.
+
+The only practical difference between libraries is **how you wrap the
+source array in a dask array**:
+
+- **JAX and CuPy** expose NumPy-compatible dtype objects, so
+  :func:`dask.array.from_array` works without any extra arguments.
+- **PyTorch** uses its own dtype objects (``torch.complex64``, etc.)
+  which are not recognised by NumPy at graph-construction time, so
+  :func:`dask.array.from_delayed` with an explicit ``dtype`` is required.
+
+JAX
+^^^
+
+:func:`dask.array.from_array` works directly with ``jax.Array`` objects.
+Each chunk will be a ``jax.Array``; dask-ms converts it to NumPy inside
+the write task.
+
+.. code-block:: python
+
+    import dask
+    import dask.array as da
+    import jax.numpy as jnp
+    from daskms import xds_from_ms, xds_to_table
+
+    ms = "path/to/data.ms"
+    ds = xds_from_ms(ms, columns=["DATA"], group_cols=[],
+                     chunks={"row": 100})[0]
+    dims, chunks = ds.sizes, ds.chunks
+
+    jax_data = jnp.zeros(
+        (dims["row"], dims["chan"], dims["corr"]), dtype=jnp.complex64
+    )
+    da_data = da.from_array(
+        jax_data, chunks=(chunks["row"], dims["chan"], dims["corr"])
+    )
+    new_ds = ds.assign(DATA=(("row", "chan", "corr"), da_data))
+    dask.compute(xds_to_table(new_ds, ms, ["DATA"]))
+
+This pattern also applies when ``jax.Array`` objects are produced
+per-chunk, for example from a :func:`dask.array.map_blocks` call over a
+JAX-jitted function:
+
+.. code-block:: python
+
+    import jax
+
+    @jax.jit
+    def predict(uvw_chunk):
+        ...  # returns a jax.Array of shape (row, chan, corr)
+
+    da_data = da.map_blocks(
+        predict, ds.UVW.data,
+        dtype="complex64",
+        new_axis=[1, 2],
+        chunks=(chunks["row"], dims["chan"], dims["corr"]),
+    )
+
+CuPy
+^^^^
+
+CuPy arrays live on the GPU.  :func:`dask.array.from_array` introspects
+the dtype correctly, and dask-ms transfers each chunk to CPU inside the
+write task via ``cupy.ndarray.get()``.
+
+.. code-block:: python
+
+    import dask
+    import dask.array as da
+    import cupy as cp
+    from daskms import xds_from_ms, xds_to_table
+
+    ms = "path/to/data.ms"
+    ds = xds_from_ms(ms, columns=["DATA"], group_cols=[],
+                     chunks={"row": 100})[0]
+    dims, chunks = ds.sizes, ds.chunks
+
+    cupy_data = cp.zeros(
+        (dims["row"], dims["chan"], dims["corr"]), dtype=cp.complex64
+    )
+    da_data = da.from_array(
+        cupy_data, chunks=(chunks["row"], dims["chan"], dims["corr"])
+    )
+    new_ds = ds.assign(DATA=(("row", "chan", "corr"), da_data))
+    dask.compute(xds_to_table(new_ds, ms, ["DATA"]))
+
+PyTorch
+^^^^^^^
+
+PyTorch tensor dtype objects (``torch.complex64``, etc.) are not
+NumPy-compatible, so :func:`dask.array.from_array` cannot introspect the
+dtype at graph-construction time.  Use :func:`dask.array.from_delayed`
+with an explicit NumPy ``dtype`` string instead, building one delayed
+chunk per row-chunk:
+
+.. code-block:: python
+
+    import dask
+    import dask.array as da
+    import torch
+    from daskms import xds_from_ms, xds_to_table
+
+    ms = "path/to/data.ms"
+    ds = xds_from_ms(ms, columns=["DATA"], group_cols=[],
+                     chunks={"row": 100})[0]
+    dims, chunks = ds.sizes, ds.chunks
+
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    torch_data = torch.zeros(
+        dims["row"], dims["chan"], dims["corr"],
+        dtype=torch.complex64, device=device,
+    )
+
+    parts, row = [], 0
+    for rc in chunks["row"]:
+        chunk = torch_data[row: row + rc]
+        parts.append(
+            da.from_delayed(
+                dask.delayed(chunk),
+                shape=(rc, dims["chan"], dims["corr"]),
+                dtype="complex64",  # NumPy dtype — no torch dependency here
+            )
+        )
+        row += rc
+    da_data = da.concatenate(parts, axis=0)
+
+    new_ds = ds.assign(DATA=(("row", "chan", "corr"), da_data))
+    dask.compute(xds_to_table(new_ds, ms, ["DATA"]))
+
+For CUDA tensors, the device-to-host transfer (``tensor.to("cpu")``) is
+performed inside each write task.  For CPU tensors no copy is made at the
+dask layer.


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
