### PR TITLE
Fix is_katdal_url for subtables

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+X.Y.Z (YYYY-MM-DD)
+------------------
+* Fix ``is_katdal_url`` which was returning False for url's containing a subtable (:pr:`372`)
+
 0.2.31 (2026-05-11)
 -------------------
 * Fix writes for arrays from array API compatible libraries (JAX, CuPy,

--- a/daskms/dask_ms.py
+++ b/daskms/dask_ms.py
@@ -342,10 +342,17 @@ def is_katdal_url(store) -> bool:
     """Returns true if this is probably a katdal url
 
     katdal urls are of the form
-    "(http|https)://archive-gw-1.kat.ac.za/{bid}/{bid}_sdp_l0.full.rdb?token={xyz}"
+    "(http|https)://archive-gw-1.kat.ac.za/{bid}/{bid}_sdp_l0.full.rdb?token={xyz}::{subtable}"
     where bid is the capture block id.
     """
-    pr = urlparse(str(store))
+    url = str(store)
+
+    try:
+        base_url, _ = url.split("::", 1)
+    except ValueError:
+        base_url = url
+
+    pr = urlparse(base_url)
     return (
         "kat.ac.za" in pr.netloc
         and pr.path.endswith("rdb")

--- a/daskms/experimental/katdal/tests/test_chunkstore.py
+++ b/daskms/experimental/katdal/tests/test_chunkstore.py
@@ -8,6 +8,7 @@ import dask
 import numpy as np
 from numpy.testing import assert_array_equal
 
+from daskms.dask_ms import is_katdal_url
 from daskms.experimental.zarr import xds_from_zarr, xds_to_zarr
 from daskms.experimental.katdal.msv2_facade import XArrayMSv2Facade
 
@@ -156,3 +157,16 @@ def test_facade_subtable_group_cols(katdal_dataset, auto_corrs, row_dim):
     assert len(subtables["ANTENNA"]) == 4 and all(
         ds.sizes["row"] == 1 for ds in subtables["ANTENNA"]
     )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://archive-gw-1.kat.ac.za/12345/12345_sdp_l0.full.rdb",
+        "http://archive-gw-1.kat.ac.za/12345/12345_sdp_l0.full.rdb::FIELD",
+        "https://archive-gw-1.kat.ac.za/12345/12345_sdp_l0.full.rdb?token=eyABCD",
+        "https://archive-gw-1.kat.ac.za/12345/12345_sdp_l0.full.rdb?token=eyABCD::FIELD",
+    ],
+)
+def test_is_katdal_url(url):
+    assert is_katdal_url(url)


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [ ] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```


<!-- readthedocs-preview dask-ms start -->
----
📚 Documentation preview 📚: https://dask-ms--372.org.readthedocs.build/en/372/

<!-- readthedocs-preview dask-ms end -->