### PR TITLE
Introduce `pytest != 9.1.0` restriction

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+X.Y.Z (YYYY-MM-DD)
+------------------
+* Introduce pytest != 9.1.0 version restriction (:pr:`375`)
+
 0.2.32 (2026-05-18)
 ------------------
 * Fix ``is_katdal_url`` which was returning False for url's containing a subtable (:pr:`372`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ complete = [
     'xarray>=2023.01.0', 'zarr (>= 2.12.0, < 3.0.0)',
     'numcodecs < 0.16.0',
     'katdal >= 0.23']
-testing = ['minio >=7.2.0', 'pytest >=8.0.0']
+testing = ['minio >=7.2.0', 'pytest >=8.0.0, != 9.1.0']
 dev = [
     "pre-commit>=4.3.0",
     "ruff>=0.14.0",


### PR DESCRIPTION
py.test 9.1.0 introduces the following regression

- https://github.com/pytest-dev/pytest/issues/14591

<!-- empty -->

- [x] Tests added / passed

  ```bash
  $ py.test -v -s daskms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i daskms
  $ flake8 daskms
  $ pycodestyle daskms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```


<!-- readthedocs-preview dask-ms start -->
----
📚 Documentation preview 📚: https://dask-ms--375.org.readthedocs.build/en/375/

<!-- readthedocs-preview dask-ms end -->